### PR TITLE
feat: support redraw command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ pterm list
 # Get socket path for a session
 pterm socket mysession
 
+# Redraw terminal (resend snapshot to all clients)
+pterm redraw mysession
+
 # Kill a session
 pterm kill mysession
 ```
@@ -32,6 +35,7 @@ pterm kill mysession
 :Pterm              " opens/creates default session
 :Pterm dev          " opens/creates named session
 :PtermList          " list sessions
+:PtermRedraw dev    " redraw a session
 :PtermKill dev      " kill a session
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,19 @@ Processes survive Neovim restarts. Terminal rendering is delegated to Neovim's n
 ```sh
 # Create a new persistent session (forks into background)
 pterm new mysession
+pterm new mysession --cols 120 --rows 40
+pterm new mysession -- /bin/zsh        # custom command
 
 # Attach bridge mode (for terminal clients)
 pterm attach mysession
 
 # Attach if exists, otherwise create and attach
 pterm open mysession
+pterm open mysession -- /bin/zsh
 
-# List active sessions
+# List active sessions (optionally filter by prefix)
 pterm list
+pterm list myprefix
 
 # Get socket path for a session
 pterm socket mysession
@@ -29,17 +33,28 @@ pterm redraw mysession
 pterm kill mysession
 ```
 
+Session names may contain `/` for hierarchical sessions. Killing a parent session also kills all children.
+
+```sh
+pterm new parent
+pterm new parent/child
+pterm kill parent          # kills parent and parent/child
+```
+
 ## Neovim Usage
 
 ```vim
-:Pterm              " opens/creates default session
+:Pterm              " opens/creates 'main' session
 :Pterm dev          " opens/creates named session
+:Pterm dev zsh      " opens/creates session with custom command
 :PtermList          " list sessions
 :PtermRedraw dev    " redraw a session
 :PtermKill dev      " kill a session
 ```
 
 `pterm` opens a terminal buffer backed by `jobstart({ "pterm", "attach", <name> }, { term = true })`.
+
+The Lua module also exports functions for programmatic use: `open`, `attach`, `detach`, `list`, `kill`, `redraw`.
 
 ## Requirements
 
@@ -75,7 +90,7 @@ require("pterm").setup({
   binary = nil,
   -- Default shell command
   shell = vim.env.SHELL or "/bin/sh",
-  -- Default terminal size
+  -- Fallback terminal size (Neovim window size takes priority)
   cols = 80,
   rows = 24,
   -- Socket directory (nil = let daemon decide)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -107,6 +107,7 @@ Client -> daemon:
 - `INPUT` (`0x01`): raw keyboard bytes
 - `RESIZE` (`0x02`): `cols:u16, rows:u16`
 - `DETACH` (`0x03`): empty payload
+- `REDRAW` (`0x04`): empty payload; requests daemon to resend terminal snapshot to all clients
 
 Daemon -> client:
 

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -289,6 +289,20 @@ function M.detach(session_name)
 	end
 end
 
+--- Redraw a session (resend terminal snapshot to all clients).
+function M.redraw(session_name)
+	if not session_name then
+		vim.notify("Session name required", vim.log.levels.ERROR)
+		return
+	end
+
+	local bin = find_binary()
+	vim.fn.system({ bin, "redraw", session_name })
+	if vim.v.shell_error ~= 0 then
+		vim.notify("Failed to redraw session '" .. session_name .. "'", vim.log.levels.ERROR)
+	end
+end
+
 --- Setup function for lazy.nvim / packer etc.
 function M.setup(opts)
 	M.config = vim.tbl_deep_extend("force", M.config, opts or {})
@@ -313,6 +327,16 @@ function M.setup(opts)
 			end
 		end
 	end, { desc = "List active pterm sessions" })
+
+	vim.api.nvim_create_user_command("PtermRedraw", function(cmd_opts)
+		M.redraw(cmd_opts.fargs[1])
+	end, {
+		nargs = 1,
+		complete = function()
+			return M.list()
+		end,
+		desc = "Redraw a persistent terminal session",
+	})
 
 	vim.api.nvim_create_user_command("PtermKill", function(cmd_opts)
 		M.kill(cmd_opts.fargs[1])

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -289,7 +289,9 @@ function M.detach(session_name)
 	end
 end
 
---- Redraw a session (resend terminal snapshot to all clients).
+--- Redraw a session (resend terminal snapshot via the daemon).
+--- Stateless: no buffer or window changes. The daemon sends a SCROLLBACK
+--- message through the existing bridge, which writes it to Neovim's terminal.
 function M.redraw(session_name)
 	if not session_name then
 		vim.notify("Session name required", vim.log.levels.ERROR)

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -14,6 +14,9 @@ pub mod client {
 
     /// Graceful detach request (no payload)
     pub const DETACH: u8 = 0x03;
+
+    /// Request terminal redraw (no payload)
+    pub const REDRAW: u8 = 0x04;
 }
 
 /// Daemon → Client message types

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ Usage:
                # attach if exists, otherwise create and attach
   pterm list   [prefix]
   pterm kill   <session-name>
+  pterm redraw <session-name>   # redraw terminal (resend snapshot)
   pterm socket <session-name>   # print socket path
 
 Session names may contain '/' for hierarchical sessions:
@@ -349,6 +350,24 @@ fn cmd_open(args: &[String]) -> io::Result<()> {
     std::process::exit(exit_code);
 }
 
+fn cmd_redraw(args: &[String]) -> io::Result<()> {
+    let name = args.first().map(|s| s.as_str()).unwrap_or_else(|| {
+        eprintln!("Error: session name required");
+        std::process::exit(1);
+    });
+
+    let sock = session_socket_path(name);
+    if !sock.exists() {
+        eprintln!("Error: session '{}' not found", name);
+        std::process::exit(1);
+    }
+
+    let mut stream = std::os::unix::net::UnixStream::connect(&sock)?;
+    let msg = pterm_proto::encode(pterm_proto::client::REDRAW, &[]);
+    std::io::Write::write_all(&mut stream, &msg)?;
+    Ok(())
+}
+
 fn cmd_socket(args: &[String]) -> io::Result<()> {
     let name = args.first().map(|s| s.as_str()).unwrap_or_else(|| {
         eprintln!("Error: session name required");
@@ -374,6 +393,7 @@ fn main() {
         "open" => cmd_open(&args[2..]),
         "list" | "ls" => cmd_list(&args[2..]),
         "kill" => cmd_kill(&args[2..]),
+        "redraw" => cmd_redraw(&args[2..]),
         "socket" => cmd_socket(&args[2..]),
         "-h" | "--help" | "help" => {
             print_usage();

--- a/src/server.rs
+++ b/src/server.rs
@@ -310,6 +310,15 @@ impl Server {
                     }
                 }
                 proto::client::DETACH => {}
+                proto::client::REDRAW => {
+                    log::info!("Redraw requested by client {}", client_id);
+                    let mut redraw_data = b"\x1b[2J\x1b[H".to_vec();
+                    redraw_data.extend_from_slice(&self.session.snapshot());
+                    let msg = proto::encode(proto::server::SCROLLBACK, &redraw_data);
+                    for (_, client) in self.clients.iter_mut() {
+                        client.send_buf.extend_from_slice(&msg);
+                    }
+                }
                 _ => log::warn!("Unknown message type: 0x{:02x}", msg_type),
             }
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -97,14 +97,24 @@ impl Server {
 
             for event in events.iter() {
                 match event.token() {
-                    LISTENER => self.accept_client()?,
+                    LISTENER => {
+                        if let Err(e) = self.accept_client() {
+                            log::warn!("Failed to accept client: {}", e);
+                        }
+                    }
                     token if token.0 >= CLIENT_BASE.0 => {
                         let id = token.0 - CLIENT_BASE.0;
                         if event.is_readable() {
-                            self.handle_client_data(id, &mut client_buf)?;
+                            if let Err(e) = self.handle_client_data(id, &mut client_buf) {
+                                log::warn!("Client {} read error: {}", id, e);
+                                self.clients.remove(&id);
+                            }
                         }
                         if event.is_writable() {
-                            self.flush_client_send_buf(id)?;
+                            if let Err(e) = self.flush_client_send_buf(id) {
+                                log::warn!("Client {} write error: {}", id, e);
+                                self.clients.remove(&id);
+                            }
                         }
                     }
                     PTY_BASE => self.handle_pty_output(&mut pty_buf)?,
@@ -165,7 +175,12 @@ impl Server {
                         }
                     }
 
-                    self.flush_client_send_buf(id)?;
+                    if let Err(e) = self.flush_client_send_buf(id) {
+                        log::warn!(
+                            "Client {} flush error during accept, deferring to event loop: {}",
+                            id, e
+                        );
+                    }
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => break,
                 Err(e) => return Err(e),
@@ -247,6 +262,20 @@ impl Server {
         self.set_client_interest(client_id, writable)
     }
 
+    fn flush_all_clients(&mut self) {
+        let ids: Vec<usize> = self.clients.keys().copied().collect();
+        let mut disconnected = Vec::new();
+        for id in ids {
+            if self.flush_client_send_buf(id).is_err() {
+                disconnected.push(id);
+            }
+        }
+        for id in disconnected {
+            log::info!("Client {} disconnected during flush", id);
+            self.clients.remove(&id);
+        }
+    }
+
     fn handle_client_data(&mut self, client_id: usize, buf: &mut [u8]) -> io::Result<()> {
         let remove = {
             let client = match self.clients.get_mut(&client_id) {
@@ -269,19 +298,23 @@ impl Server {
             self.clients.remove(&client_id);
         } else if let Some(client) = self.clients.get_mut(&client_id) {
             if !client.recv_buf.is_empty() {
-                self.process_client_recv_buf(client_id)?;
+                let needs_flush = self.process_client_recv_buf(client_id)?;
+                if needs_flush {
+                    self.flush_all_clients();
+                }
             }
         }
         Ok(())
     }
 
-    fn process_client_recv_buf(&mut self, client_id: usize) -> io::Result<()> {
+    fn process_client_recv_buf(&mut self, client_id: usize) -> io::Result<bool> {
         // Take the buffer out to avoid borrowing self.clients while using self.session
         let mut recv_buf = match self.clients.get_mut(&client_id) {
             Some(c) => std::mem::take(&mut c.recv_buf),
-            None => return Ok(()),
+            None => return Ok(false),
         };
 
+        let mut flush_all = false;
         let mut offset = 0;
         while offset + proto::HEADER_SIZE <= recv_buf.len() {
             let header: [u8; proto::HEADER_SIZE] = recv_buf[offset..offset + proto::HEADER_SIZE]
@@ -318,6 +351,7 @@ impl Server {
                     for (_, client) in self.clients.iter_mut() {
                         client.send_buf.extend_from_slice(&msg);
                     }
+                    flush_all = true;
                 }
                 _ => log::warn!("Unknown message type: 0x{:02x}", msg_type),
             }
@@ -330,7 +364,7 @@ impl Server {
         if let Some(client) = self.clients.get_mut(&client_id) {
             client.recv_buf = recv_buf;
         }
-        Ok(())
+        Ok(flush_all)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add REDRAW message type to protocol and handle it in server to resend terminal snapshot
- Add `pterm redraw <session-name>` CLI command
- Add `:PtermRedraw` command in Neovim plugin
- Improve server error handling: gracefully handle client I/O errors instead of propagating, and flush all clients after redraw broadcast
- Update README to better reflect current implementation (CLI options, hierarchical sessions, Lua API)

## Commits
- `feat(server): handle redraw request`
- `feat(cli): add redraw command`
- `feat(nvim): add PtermRedraw command`
- `fix(server): improve error handling and flush after redraw broadcast`

## Test plan
- [ ] `pterm new test && pterm redraw test` works correctly
- [ ] `:PtermRedraw test` resends terminal snapshot in Neovim
- [ ] Client disconnection during redraw does not crash the server
- [ ] README content matches CLI `--help` output