### PR TITLE
feat: add Telescope extension for pterm sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ require("pterm").setup({
 })
 ```
 
+## Telescope Extension
+
+pterm provides an optional [Telescope](https://github.com/nvim-telescope/telescope.nvim) extension for fuzzy-finding sessions.
+
+```lua
+-- Call after telescope.setup()
+require("telescope").load_extension("pterm")
+```
+
+```vim
+:Telescope pterm sessions
+```
+
+Connected sessions are shown with a `[connected]` prefix.
+
 ## License
 
 MIT

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -349,6 +349,10 @@ function M.setup(opts)
 		end,
 		desc = "Kill a persistent terminal session",
 	})
+
+	pcall(function()
+		require("telescope").load_extension("pterm")
+	end)
 end
 
 return M

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -409,10 +409,6 @@ function M.setup(opts)
 		end,
 		desc = "Kill a persistent terminal session",
 	})
-
-	pcall(function()
-		require("telescope").load_extension("pterm")
-	end)
 end
 
 return M

--- a/lua/telescope/_extensions/pterm.lua
+++ b/lua/telescope/_extensions/pterm.lua
@@ -1,0 +1,87 @@
+local telescope = require("telescope")
+local pickers = require("telescope.pickers")
+local finders = require("telescope.finders")
+local conf = require("telescope.config").values
+local actions = require("telescope.actions")
+local action_state = require("telescope.actions.state")
+
+local function session_exists(pterm, session_name)
+	for _, name in ipairs(pterm.list()) do
+		if name == session_name then
+			return true
+		end
+	end
+	return false
+end
+
+local function sessions(opts)
+	opts = opts or {}
+
+	local ok, pterm = pcall(require, "pterm")
+	if not ok then
+		vim.notify("Failed to load pterm module", vim.log.levels.ERROR)
+		return
+	end
+
+	local session_names = pterm.list()
+	if #session_names == 0 then
+		vim.notify("No active pterm sessions", vim.log.levels.INFO)
+		return
+	end
+
+	local entries = {}
+	for _, name in ipairs(session_names) do
+		local connected = pterm.connections[name] ~= nil
+		table.insert(entries, {
+			value = name,
+			ordinal = name,
+			display = connected and ("[connected] " .. name) or name,
+		})
+	end
+
+	pickers
+		.new(opts, {
+			prompt_title = "pterm sessions",
+			finder = finders.new_table({
+				results = entries,
+				entry_maker = function(entry)
+					return {
+						value = entry.value,
+						ordinal = entry.ordinal,
+						display = entry.display,
+					}
+				end,
+			}),
+			sorter = conf.generic_sorter(opts),
+			attach_mappings = function(prompt_bufnr)
+				actions.select_default:replace(function()
+					actions.close(prompt_bufnr)
+
+					local selection = action_state.get_selected_entry()
+					if not selection or not selection.value then
+						return
+					end
+
+					local session_name = selection.value
+					if not session_exists(pterm, session_name) then
+						vim.notify("Session '" .. session_name .. "' not found", vim.log.levels.ERROR)
+						return
+					end
+
+					local open_ok, err = pcall(pterm.open, session_name)
+					if not open_ok then
+						vim.notify("Failed to open session '" .. session_name .. "': " .. tostring(err), vim.log.levels.ERROR)
+					end
+				end)
+				return true
+			end,
+		})
+		:find()
+end
+
+return telescope.register_extension({
+	exports = {
+		sessions = sessions,
+		pterm = sessions,
+	},
+})


### PR DESCRIPTION
## Summary

- `lua/telescope/_extensions/pterm.lua` を新規追加し、`:Telescope pterm sessions` で pterm セッションを fuzzy search できる Telescope picker を実装
- 接続済みセッションは `[connected] <name>` で視覚的に区別
- セッションが消えていた場合は `vim.notify` でエラー通知（クラッシュしない）
- `load_extension` の自動呼び出しを削除し、ユーザーが明示的に `require("telescope").load_extension("pterm")` を呼ぶ標準パターンに変更
  - telescope-fzf-native, telescope-file-browser, telescope-frecency 等の主要拡張と同じ方針

Closes #4

## Usage

```lua
require("pterm").setup({ ... })

-- Telescope extension (optional, call after telescope.setup)
require("telescope").load_extension("pterm")
```

## Test plan

- [ ] `:Telescope pterm sessions` でセッション一覧が表示される
- [ ] 入力による fuzzy filtering が動作する
- [ ] セッションを選択すると該当セッションにジャンプする
- [ ] 接続済みセッションが `[connected]` prefix で表示される
- [ ] 存在しないセッションを選択すると、エラー通知が出てクラッシュしない
- [ ] Telescope 未導入環境でも `require("pterm").setup()` がエラーなく動作する
- [ ] `load_extension` を呼ばなくてもセットアップがエラーにならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)