### PR TITLE
Fix rendering instability in normal Neovim windows

### DIFF
--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -213,7 +213,24 @@ function M.attach(session_name)
 	local buf = vim.api.nvim_create_buf(true, false)
 	vim.api.nvim_set_current_buf(buf)
 
-	local job_id = vim.fn.jobstart({ bin, "attach", session_name }, {
+	-- Set window-local options appropriate for a terminal buffer.
+	local win = vim.api.nvim_get_current_win()
+	vim.api.nvim_set_option_value("number", false, { win = win })
+	vim.api.nvim_set_option_value("relativenumber", false, { win = win })
+	vim.api.nvim_set_option_value("signcolumn", "no", { win = win })
+	vim.api.nvim_set_option_value("foldcolumn", "0", { win = win })
+	vim.api.nvim_set_option_value("statuscolumn", "", { win = win })
+
+	-- Pass the current window size so the bridge sends an accurate initial
+	-- RESIZE before the daemon generates the snapshot.
+	local win_cols = vim.api.nvim_win_get_width(win)
+	local win_rows = vim.api.nvim_win_get_height(win)
+
+	local job_id = vim.fn.jobstart({
+		bin, "attach", session_name,
+		"--cols", tostring(win_cols),
+		"--rows", tostring(win_rows),
+	}, {
 		term = true,
 		on_exit = function(_, exit_code, _)
 			vim.schedule(function()
@@ -254,6 +271,49 @@ function M.attach(session_name)
 			M.detach(session_name)
 		end,
 	})
+
+	-- Propagate resize events to the bridge process via jobresize().
+	-- VimResized fires on SIGWINCH (whole Neovim frame resized).
+	vim.api.nvim_create_autocmd("VimResized", {
+		group = augroup,
+		callback = function()
+			local conn = M.connections[session_name]
+			if not conn or not conn.job_id then
+				return
+			end
+			-- Find all windows showing this terminal buffer and resize each.
+			for _, w in ipairs(vim.api.nvim_list_wins()) do
+				if vim.api.nvim_win_is_valid(w) and vim.api.nvim_win_get_buf(w) == conn.buf then
+					local cols = vim.api.nvim_win_get_width(w)
+					local rows = vim.api.nvim_win_get_height(w)
+					pcall(vim.fn.jobresize, conn.job_id, cols, rows)
+					break -- one jobresize is enough; the bridge sends RESIZE to daemon
+				end
+			end
+		end,
+	})
+
+	-- WinResized fires when individual windows change size (Neovim ≥ 0.9).
+	if vim.fn.exists("##WinResized") == 1 then
+		vim.api.nvim_create_autocmd("WinResized", {
+			group = augroup,
+			callback = function()
+				local conn = M.connections[session_name]
+				if not conn or not conn.job_id then
+					return
+				end
+				local resized_wins = vim.v.event and vim.v.event.windows or {}
+				for _, w in ipairs(resized_wins) do
+					if vim.api.nvim_win_is_valid(w) and vim.api.nvim_win_get_buf(w) == conn.buf then
+						local cols = vim.api.nvim_win_get_width(w)
+						local rows = vim.api.nvim_win_get_height(w)
+						pcall(vim.fn.jobresize, conn.job_id, cols, rows)
+						break
+					end
+				end
+			end,
+		})
+	end
 
 	vim.cmd("startinsert")
 end

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -99,7 +99,15 @@ fn write_all_raw(fd: RawFd, data: &[u8]) -> io::Result<()> {
 
 /// Run the bridge, connecting stdin/stdout to the daemon session at `socket_path`.
 /// Returns the child process exit code (from the daemon's EXIT message).
-pub fn run(socket_path: &Path) -> io::Result<i32> {
+///
+/// `initial_cols` / `initial_rows` override the terminal size sent in the
+/// initial RESIZE message.  When `None`, the size is read from `TIOCGWINSZ`
+/// (stdout) with a final fallback to 80×24.
+pub fn run(
+    socket_path: &Path,
+    initial_cols: Option<u16>,
+    initial_rows: Option<u16>,
+) -> io::Result<i32> {
     let stdin_fd = libc::STDIN_FILENO;
     let stdout_fd = libc::STDOUT_FILENO;
 
@@ -148,8 +156,19 @@ pub fn run(socket_path: &Path) -> io::Result<i32> {
     poll.registry()
         .register(&mut wake_source, TOKEN_WAKE, Interest::READABLE)?;
 
-    // Send initial RESIZE to sync terminal size
-    if let Ok((cols, rows)) = get_winsize(stdout_fd) {
+    // Send initial RESIZE to sync terminal size.
+    // CLI-supplied values take priority, then TIOCGWINSZ, then 80×24.
+    let (cols, rows) = {
+        let winsize = get_winsize(stdout_fd).ok();
+        let c = initial_cols
+            .or(winsize.map(|(c, _)| c))
+            .unwrap_or(80);
+        let r = initial_rows
+            .or(winsize.map(|(_, r)| r))
+            .unwrap_or(24);
+        (c, r)
+    };
+    {
         let resize_payload = proto::encode_resize(cols, rows);
         let msg = proto::encode(proto::client::RESIZE, &resize_payload);
         socket.write_all(&msg)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,8 @@ fn print_usage() {
 
 Usage:
   pterm new    <session-name> [--cols N] [--rows N] [--] <command> [args...]
-  pterm attach <session-name>   # attach to session (bridge mode)
+  pterm attach <session-name> [--cols N] [--rows N]
+               # attach to session (bridge mode)
   pterm open   <session-name> [--cols N] [--rows N] [--] <command> [args...]
                # attach if exists, otherwise create and attach
   pterm list   [prefix]
@@ -312,18 +313,36 @@ fn wait_for_socket(sock: &Path, timeout: Duration, poll: Duration) -> io::Result
 }
 
 fn cmd_attach(args: &[String]) -> io::Result<()> {
-    let name = args.first().map(|s| s.as_str()).unwrap_or_else(|| {
-        eprintln!("Error: session name required");
-        std::process::exit(1);
-    });
+    let mut session_name = String::new();
+    let mut cols: Option<u16> = None;
+    let mut rows: Option<u16> = None;
 
-    let sock = session_socket_path(name);
-    if !sock.exists() {
-        eprintln!("Error: session '{}' not found", name);
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--cols" {
+            i += 1;
+            cols = args.get(i).and_then(|s| s.parse().ok());
+        } else if args[i] == "--rows" {
+            i += 1;
+            rows = args.get(i).and_then(|s| s.parse().ok());
+        } else if session_name.is_empty() {
+            session_name = args[i].clone();
+        }
+        i += 1;
+    }
+
+    if session_name.is_empty() {
+        eprintln!("Error: session name required");
         std::process::exit(1);
     }
 
-    let exit_code = bridge::run(&sock)?;
+    let sock = session_socket_path(&session_name);
+    if !sock.exists() {
+        eprintln!("Error: session '{}' not found", session_name);
+        std::process::exit(1);
+    }
+
+    let exit_code = bridge::run(&sock, cols, rows)?;
     std::process::exit(exit_code);
 }
 
@@ -332,6 +351,23 @@ fn cmd_open(args: &[String]) -> io::Result<()> {
         eprintln!("Error: session name required");
         std::process::exit(1);
     });
+
+    // Extract --cols/--rows for bridge
+    let mut cols: Option<u16> = None;
+    let mut rows: Option<u16> = None;
+    {
+        let mut i = 0;
+        while i < args.len() {
+            if args[i] == "--cols" {
+                i += 1;
+                cols = args.get(i).and_then(|s| s.parse().ok());
+            } else if args[i] == "--rows" {
+                i += 1;
+                rows = args.get(i).and_then(|s| s.parse().ok());
+            }
+            i += 1;
+        }
+    }
 
     let sock = session_socket_path(name);
     if !sock.exists() {
@@ -346,7 +382,7 @@ fn cmd_open(args: &[String]) -> io::Result<()> {
         }
     }
 
-    let exit_code = bridge::run(&sock)?;
+    let exit_code = bridge::run(&sock, cols, rows)?;
     std::process::exit(exit_code);
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,15 +6,25 @@ use std::collections::HashMap;
 use std::io::{self, Read, Write};
 use std::os::unix::fs::FileTypeExt;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 const LISTENER: Token = Token(0);
 const PTY_BASE: Token = Token(0x1000_0000);
 const CLIENT_BASE: Token = Token(0x2000_0000);
 
+/// Per-connection timeout before we send the initial snapshot.
+/// This gives the client time to send a RESIZE with its actual window size
+/// so the snapshot is generated at the correct dimensions.
+const SNAPSHOT_DEFER_MS: u64 = 500;
+
 struct Client {
     stream: UnixStream,
     recv_buf: Vec<u8>,
     send_buf: Vec<u8>,
+    /// `true` until the initial snapshot has been sent.
+    pending_snapshot: bool,
+    /// Deadline after which we send the snapshot even without a RESIZE.
+    pending_snapshot_deadline: Option<Instant>,
 }
 
 pub struct Server {
@@ -122,6 +132,32 @@ impl Server {
                 }
             }
 
+            // Send deferred snapshots for clients whose deadline has expired
+            // without receiving a RESIZE (backwards compatibility with plain
+            // `pterm attach` from a raw terminal).
+            let now = Instant::now();
+            let pending_ids: Vec<usize> = self
+                .clients
+                .iter()
+                .filter_map(|(&id, c)| {
+                    if c.pending_snapshot {
+                        if let Some(deadline) = c.pending_snapshot_deadline {
+                            if now >= deadline {
+                                return Some(id);
+                            }
+                        }
+                    }
+                    None
+                })
+                .collect();
+            for id in pending_ids {
+                log::info!(
+                    "Client {} snapshot deadline expired, sending snapshot",
+                    id
+                );
+                self.send_snapshot_to_client(id);
+            }
+
             if let Some(exit_code) = self.session.check_exit() {
                 log::info!("Child exited with code {}", exit_code);
                 let msg = proto::encode(proto::server::EXIT, &exit_code.to_le_bytes());
@@ -157,7 +193,8 @@ impl Server {
 
                     log::info!("Client {} connected to '{}'", id, self.session.name);
 
-                    let snapshot = self.session.snapshot();
+                    let deadline = Instant::now()
+                        + std::time::Duration::from_millis(SNAPSHOT_DEFER_MS);
 
                     self.clients.insert(
                         id,
@@ -165,28 +202,36 @@ impl Server {
                             stream,
                             recv_buf: Vec::new(),
                             send_buf: Vec::new(),
+                            pending_snapshot: true,
+                            pending_snapshot_deadline: Some(deadline),
                         },
                     );
-
-                    if !snapshot.is_empty() {
-                        let msg = proto::encode(proto::server::SCROLLBACK, &snapshot);
-                        if let Some(client) = self.clients.get_mut(&id) {
-                            client.send_buf.extend_from_slice(&msg);
-                        }
-                    }
-
-                    if let Err(e) = self.flush_client_send_buf(id) {
-                        log::warn!(
-                            "Client {} flush error during accept, deferring to event loop: {}",
-                            id, e
-                        );
-                    }
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => break,
                 Err(e) => return Err(e),
             }
         }
         Ok(())
+    }
+
+    /// Send the current terminal snapshot to a specific client and clear its
+    /// pending-snapshot flag.
+    fn send_snapshot_to_client(&mut self, client_id: usize) {
+        let snapshot = self.session.snapshot();
+        if let Some(client) = self.clients.get_mut(&client_id) {
+            client.pending_snapshot = false;
+            client.pending_snapshot_deadline = None;
+            if !snapshot.is_empty() {
+                let msg = proto::encode(proto::server::SCROLLBACK, &snapshot);
+                client.send_buf.extend_from_slice(&msg);
+            }
+        }
+        if let Err(e) = self.flush_client_send_buf(client_id) {
+            log::warn!(
+                "Client {} flush error during snapshot send: {}",
+                client_id, e
+            );
+        }
     }
 
     fn handle_pty_output(&mut self, buf: &mut [u8]) -> io::Result<()> {
@@ -340,6 +385,17 @@ impl Server {
                         let r: [u8; 4] = payload[..4].try_into().unwrap();
                         let (cols, rows) = proto::decode_resize(&r);
                         self.session.resize(cols, rows)?;
+
+                        // If this client still has a pending snapshot, the
+                        // session has now been resized to the correct
+                        // dimensions.  Generate and send the snapshot.
+                        let needs_snapshot = self
+                            .clients
+                            .get(&client_id)
+                            .map_or(false, |c| c.pending_snapshot);
+                        if needs_snapshot {
+                            self.send_snapshot_to_client(client_id);
+                        }
                     }
                 }
                 proto::client::DETACH => {}


### PR DESCRIPTION
## Summary

- **Deferred snapshot delivery**: Server no longer sends the terminal snapshot immediately on client connect. Instead, it waits for the client's initial RESIZE (up to 500ms timeout) so the snapshot is generated at the correct window dimensions, eliminating the snapshot/RESIZE race condition.
- **CLI `--cols`/`--rows` for attach/open**: The bridge process now accepts explicit window size arguments, allowing Lua to pass the actual Neovim window dimensions directly.
- **Resize propagation via autocmds**: Added `VimResized` and `WinResized` (Neovim ≥ 0.9) autocmds that call `jobresize()` to propagate window size changes to the bridge process.
- **Terminal window options**: Sets `number=false`, `relativenumber=false`, `signcolumn="no"`, `foldcolumn="0"`, `statuscolumn=""` on the terminal window to prevent layout artifacts.

## Test plan

- [ ] `cargo build` / `cargo test` pass
- [ ] Open pterm in a normal window (`:Pterm`) — rendering should be stable
- [ ] Resize the Neovim window — terminal display should follow
- [ ] Split window resize propagates correctly
- [ ] Re-attach to existing session shows correct-size snapshot
- [ ] Raw terminal `pterm attach` still works (500ms fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)