### PR TITLE
fix: coalesce PTY output to prevent fragmented prompt rendering

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -78,12 +78,8 @@ Notable behavior:
 - session socket path: `<socket_root>/<session>/socket`
 - if socket file is removed externally, daemon treats session as deleted and exits
 - output delivery uses per-client send queues and writable polling to avoid disconnecting on backpressure (`WouldBlock`)
-- **deferred snapshot**: on connect, waits up to 500ms for the client to send RESIZE before generating the initial snapshot, ensuring correct terminal dimensions
-- **micro-batching**: PTY output is coalesced using bounded micro-batching (similar to tmux) to prevent prompt fragmentation on fast machines:
-  - after a read, holds output for up to 1ms (`BATCH_DELAY_MS`) to coalesce nearby shell writes
-  - maximum burst hold time is 3ms (`BATCH_MAX_MS`)
-  - flushes immediately when the pending buffer reaches 4096 bytes (`BATCH_FLUSH_SIZE`)
-  - poll timeout is dynamically computed as `min(100ms, batch_deadline, snapshot_deadlines)`
+- **snapshot delivery**: no timer-based deferral; snapshot is sent either when the client sends RESIZE (correct dimensions) or when the first PTY OUTPUT arrives (current dimensions as fallback)
+- **drain-and-flush**: PTY output uses non-blocking drain (reads until `WouldBlock`) followed by immediate flush — no timer-based micro-batching, minimizing latency while naturally coalescing bytes available at each poll cycle
 - EXIT message is queued into `send_buf` (not written directly) to preserve OUTPUT→EXIT ordering under backpressure, and is sent exactly once via an `exit_sent` guard
 
 ### Bridge (`src/bridge.rs`)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -78,6 +78,13 @@ Notable behavior:
 - session socket path: `<socket_root>/<session>/socket`
 - if socket file is removed externally, daemon treats session as deleted and exits
 - output delivery uses per-client send queues and writable polling to avoid disconnecting on backpressure (`WouldBlock`)
+- **deferred snapshot**: on connect, waits up to 500ms for the client to send RESIZE before generating the initial snapshot, ensuring correct terminal dimensions
+- **micro-batching**: PTY output is coalesced using bounded micro-batching (similar to tmux) to prevent prompt fragmentation on fast machines:
+  - after a read, holds output for up to 1ms (`BATCH_DELAY_MS`) to coalesce nearby shell writes
+  - maximum burst hold time is 3ms (`BATCH_MAX_MS`)
+  - flushes immediately when the pending buffer reaches 4096 bytes (`BATCH_FLUSH_SIZE`)
+  - poll timeout is dynamically computed as `min(100ms, batch_deadline, snapshot_deadlines)`
+- EXIT message is queued into `send_buf` (not written directly) to preserve OUTPUT→EXIT ordering under backpressure, and is sent exactly once via an `exit_sent` guard
 
 ### Bridge (`src/bridge.rs`)
 
@@ -93,6 +100,7 @@ Implementation notes:
 - raw mode guard for terminal settings restoration
 - framed protocol parsing with buffered partial-frame handling
 - `EINTR` on `poll` is retried
+- **output batching**: accumulates OUTPUT and SCROLLBACK payloads per poll cycle into a single `write_all_raw()` call to prevent incremental rendering on the Neovim side
 
 ## Wire Protocol
 

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -237,8 +237,10 @@ pub fn run(
                         }
                     }
 
-                    // Process complete frames
+                    // Process complete frames, batching output payloads into
+                    // a single write to avoid incremental rendering.
                     let mut offset = 0;
+                    let mut output_batch: Vec<u8> = Vec::new();
                     while offset + proto::HEADER_SIZE <= recv_buf.len() {
                         let header: [u8; proto::HEADER_SIZE] = recv_buf
                             [offset..offset + proto::HEADER_SIZE]
@@ -257,19 +259,26 @@ pub fn run(
 
                         match msg_type {
                             proto::server::OUTPUT | proto::server::SCROLLBACK => {
-                                // Write raw bytes to stdout for libvterm
-                                if write_all_raw(stdout_fd, payload).is_err() {
-                                    break 'main;
-                                }
+                                output_batch.extend_from_slice(payload);
                             }
                             proto::server::EXIT => {
                                 if payload.len() >= 4 {
                                     exit_code =
                                         i32::from_le_bytes(payload[..4].try_into().unwrap());
                                 }
+                                // Flush any batched output before exiting
+                                if !output_batch.is_empty() {
+                                    let _ = write_all_raw(stdout_fd, &output_batch);
+                                }
                                 break 'main;
                             }
                             _ => {}
+                        }
+                    }
+
+                    if !output_batch.is_empty() {
+                        if write_all_raw(stdout_fd, &output_batch).is_err() {
+                            break 'main;
                         }
                     }
 

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -160,12 +160,8 @@ pub fn run(
     // CLI-supplied values take priority, then TIOCGWINSZ, then 80×24.
     let (cols, rows) = {
         let winsize = get_winsize(stdout_fd).ok();
-        let c = initial_cols
-            .or(winsize.map(|(c, _)| c))
-            .unwrap_or(80);
-        let r = initial_rows
-            .or(winsize.map(|(_, r)| r))
-            .unwrap_or(24);
+        let c = initial_cols.or(winsize.map(|(c, _)| c)).unwrap_or(80);
+        let r = initial_rows.or(winsize.map(|(_, r)| r)).unwrap_or(24);
         (c, r)
     };
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -372,7 +372,11 @@ fn cmd_open(args: &[String]) -> io::Result<()> {
     let sock = session_socket_path(name);
     if !sock.exists() {
         cmd_new(args)?;
-        let ok = wait_for_socket(&sock, Duration::from_millis(3000), Duration::from_millis(50))?;
+        let ok = wait_for_socket(
+            &sock,
+            Duration::from_millis(3000),
+            Duration::from_millis(50),
+        )?;
         if !ok {
             eprintln!(
                 "Error: session '{}' was created but socket did not appear in time",

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -22,6 +22,13 @@ impl Pty {
         // Set initial window size
         set_winsize(master.as_raw_fd(), cols, rows)?;
 
+        // Set master fd to non-blocking so the daemon can drain all available
+        // data in a loop without blocking on the last read.
+        unsafe {
+            let flags = libc::fcntl(master.as_raw_fd(), libc::F_GETFL);
+            libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK);
+        }
+
         // Fork
         match unsafe { fork() }.map_err(io::Error::other)? {
             ForkResult::Parent { child } => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -235,28 +235,42 @@ impl Server {
     }
 
     fn handle_pty_output(&mut self, buf: &mut [u8]) -> io::Result<()> {
-        match self.session.read_pty(buf) {
-            Ok(0) => {}
-            Ok(n) => {
-                let msg = proto::encode(proto::server::OUTPUT, &buf[..n]);
-                let mut disconnected = Vec::new();
-                let mut flush_ids = Vec::new();
-                for (&id, client) in self.clients.iter_mut() {
-                    client.send_buf.extend_from_slice(&msg);
-                    flush_ids.push(id);
-                }
-                for id in flush_ids {
-                    if self.flush_client_send_buf(id).is_err() {
-                        disconnected.push(id);
+        // Drain all available PTY data into a single buffer so we send one
+        // coalesced OUTPUT message instead of many small fragments.
+        let mut output = Vec::new();
+        loop {
+            match self.session.read_pty(buf) {
+                Ok(0) => break,
+                Ok(n) => output.extend_from_slice(&buf[..n]),
+                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => break,
+                Err(e) => {
+                    if output.is_empty() {
+                        log::error!("pty read error: {}", e);
                     }
-                }
-                for id in disconnected {
-                    log::info!("Client {} disconnected", id);
-                    self.clients.remove(&id);
+                    break;
                 }
             }
-            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {}
-            Err(e) => log::error!("pty read error: {}", e),
+        }
+
+        if output.is_empty() {
+            return Ok(());
+        }
+
+        let msg = proto::encode(proto::server::OUTPUT, &output);
+        let mut disconnected = Vec::new();
+        let mut flush_ids = Vec::new();
+        for (&id, client) in self.clients.iter_mut() {
+            client.send_buf.extend_from_slice(&msg);
+            flush_ids.push(id);
+        }
+        for id in flush_ids {
+            if self.flush_client_send_buf(id).is_err() {
+                disconnected.push(id);
+            }
+        }
+        for id in disconnected {
+            log::info!("Client {} disconnected", id);
+            self.clients.remove(&id);
         }
         Ok(())
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,24 +6,11 @@ use std::collections::HashMap;
 use std::io::{self, Read, Write};
 use std::os::unix::fs::FileTypeExt;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 const LISTENER: Token = Token(0);
 const PTY_BASE: Token = Token(0x1000_0000);
 const CLIENT_BASE: Token = Token(0x2000_0000);
-
-/// Per-connection timeout before we send the initial snapshot.
-/// This gives the client time to send a RESIZE with its actual window size
-/// so the snapshot is generated at the correct dimensions.
-const SNAPSHOT_DEFER_MS: u64 = 500;
-
-/// Micro-batching constants for PTY output coalescing.
-/// After a read, wait this long before flushing to coalesce nearby writes.
-const BATCH_DELAY_MS: u64 = 1;
-/// Maximum time from the first read in a burst before we force a flush.
-const BATCH_MAX_MS: u64 = 3;
-/// If the pending buffer reaches this size, flush immediately.
-const BATCH_FLUSH_SIZE: usize = 4096;
 
 struct Client {
     stream: UnixStream,
@@ -31,8 +18,6 @@ struct Client {
     send_buf: Vec<u8>,
     /// `true` until the initial snapshot has been sent.
     pending_snapshot: bool,
-    /// Deadline after which we send the snapshot even without a RESIZE.
-    pending_snapshot_deadline: Option<Instant>,
 }
 
 pub struct Server {
@@ -44,10 +29,6 @@ pub struct Server {
     next_client_id: usize,
     /// Accumulated PTY output waiting to be flushed.
     pending_pty_output: Vec<u8>,
-    /// When the first byte of the current batch arrived.
-    batch_start: Option<Instant>,
-    /// Deadline by which the current batch must be flushed.
-    batch_deadline: Option<Instant>,
     /// `true` after the EXIT message has been broadcast to clients.
     exit_sent: bool,
 }
@@ -90,8 +71,6 @@ impl Server {
             clients: HashMap::new(),
             next_client_id: 0,
             pending_pty_output: Vec::new(),
-            batch_start: None,
-            batch_deadline: None,
             exit_sent: false,
         })
     }
@@ -122,23 +101,8 @@ impl Server {
                 }
             }
 
-            // Dynamic poll timeout: use the nearest deadline among the
-            // default 100ms, any pending snapshot deadline, and the batch
-            // flush deadline.
-            let mut poll_timeout = Duration::from_millis(100);
-            if let Some(bd) = self.batch_deadline {
-                let remaining = bd.saturating_duration_since(Instant::now());
-                poll_timeout = poll_timeout.min(remaining);
-            }
-            // Also consider snapshot deadlines.
-            for c in self.clients.values() {
-                if let Some(sd) = c.pending_snapshot_deadline {
-                    let remaining = sd.saturating_duration_since(Instant::now());
-                    poll_timeout = poll_timeout.min(remaining);
-                }
-            }
-
-            self.poll.poll(&mut events, Some(poll_timeout))?;
+            self.poll
+                .poll(&mut events, Some(Duration::from_millis(100)))?;
 
             for event in events.iter() {
                 match event.token() {
@@ -167,40 +131,10 @@ impl Server {
                 }
             }
 
-            // Flush pending PTY output if the batch deadline has expired.
-            if let Some(bd) = self.batch_deadline {
-                if Instant::now() >= bd {
-                    self.flush_pty_output();
-                }
-            }
-
-            // Send deferred snapshots for clients whose deadline has expired
-            // without receiving a RESIZE (backwards compatibility with plain
-            // `pterm attach` from a raw terminal).
-            let now = Instant::now();
-            let pending_ids: Vec<usize> = self
-                .clients
-                .iter()
-                .filter_map(|(&id, c)| {
-                    if c.pending_snapshot {
-                        if let Some(deadline) = c.pending_snapshot_deadline {
-                            if now >= deadline {
-                                return Some(id);
-                            }
-                        }
-                    }
-                    None
-                })
-                .collect();
-            if !pending_ids.is_empty() {
-                // Flush any pending PTY output before sending snapshots so
-                // the vt state is up-to-date.
-                self.flush_pty_output();
-                for id in pending_ids {
-                    log::info!("Client {} snapshot deadline expired, sending snapshot", id);
-                    self.send_snapshot_to_client(id);
-                }
-            }
+            // No timer-based snapshot deferral. Snapshots are sent either:
+            // 1. When the client sends RESIZE (handled in process_client_recv_buf)
+            // 2. When PTY OUTPUT arrives for a client still awaiting snapshot
+            //    (handled in flush_pty_output)
 
             if !self.exit_sent {
                 if let Some(exit_code) = self.session.check_exit() {
@@ -245,9 +179,6 @@ impl Server {
 
                     log::info!("Client {} connected to '{}'", id, self.session.name);
 
-                    let deadline =
-                        Instant::now() + std::time::Duration::from_millis(SNAPSHOT_DEFER_MS);
-
                     self.clients.insert(
                         id,
                         Client {
@@ -255,7 +186,6 @@ impl Server {
                             recv_buf: Vec::new(),
                             send_buf: Vec::new(),
                             pending_snapshot: true,
-                            pending_snapshot_deadline: Some(deadline),
                         },
                     );
                 }
@@ -272,7 +202,6 @@ impl Server {
         let snapshot = self.session.snapshot();
         if let Some(client) = self.clients.get_mut(&client_id) {
             client.pending_snapshot = false;
-            client.pending_snapshot_deadline = None;
             if !snapshot.is_empty() {
                 let msg = proto::encode(proto::server::SCROLLBACK, &snapshot);
                 client.send_buf.extend_from_slice(&msg);
@@ -288,19 +217,14 @@ impl Server {
     }
 
     fn handle_pty_output(&mut self, buf: &mut [u8]) -> io::Result<()> {
-        // Drain all available PTY data into the pending batch buffer.
-        let mut read_any = false;
+        // Drain all available PTY data (non-blocking) and flush immediately.
+        // No timer-based batching — the drain loop itself coalesces all bytes
+        // that are available at this instant.
         loop {
             match self.session.read_pty(buf) {
                 Ok(0) => break,
                 Ok(n) => {
-                    read_any = true;
                     self.pending_pty_output.extend_from_slice(&buf[..n]);
-
-                    // Enforce a hard size cap during draining.
-                    if self.pending_pty_output.len() >= BATCH_FLUSH_SIZE {
-                        self.flush_pty_output();
-                    }
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => break,
                 Err(e) => {
@@ -312,42 +236,42 @@ impl Server {
             }
         }
 
-        if self.pending_pty_output.is_empty() {
-            return Ok(());
-        }
-
-        // Update deadline only when this call actually read new bytes.
-        if read_any {
-            let now = Instant::now();
-            let batch_start = *self.batch_start.get_or_insert(now);
-            let max_deadline = batch_start + Duration::from_millis(BATCH_MAX_MS);
-            let delay_deadline = now + Duration::from_millis(BATCH_DELAY_MS);
-            self.batch_deadline = Some(delay_deadline.min(max_deadline));
+        if !self.pending_pty_output.is_empty() {
+            self.flush_pty_output();
         }
 
         Ok(())
     }
 
-    /// Flush accumulated PTY output to all connected clients and reset batch state.
+    /// Flush accumulated PTY output to all connected clients.
+    /// Clients still awaiting a snapshot receive the snapshot first (triggered
+    /// by the arrival of OUTPUT rather than a timer).
     fn flush_pty_output(&mut self) {
         if self.pending_pty_output.is_empty() {
             return;
         }
 
+        // Clients awaiting snapshot: the arrival of OUTPUT means the VT state
+        // is populated, so send their snapshot now (no timer needed).
+        let snapshot_ids: Vec<usize> = self
+            .clients
+            .iter()
+            .filter_map(|(&id, c)| if c.pending_snapshot { Some(id) } else { None })
+            .collect();
+        for id in snapshot_ids {
+            log::info!(
+                "Client {} snapshot triggered by PTY output arrival",
+                id
+            );
+            self.send_snapshot_to_client(id);
+        }
+
         let msg = proto::encode(proto::server::OUTPUT, &self.pending_pty_output);
         self.pending_pty_output.clear();
-        self.batch_start = None;
-        self.batch_deadline = None;
 
         let mut disconnected = Vec::new();
         let mut flush_ids = Vec::new();
         for (&id, client) in self.clients.iter_mut() {
-            // A newly attached client must receive a coherent snapshot first.
-            // Sending live OUTPUT before that can interleave mid-sequence bytes
-            // with snapshot replay and corrupt rendering.
-            if client.pending_snapshot {
-                continue;
-            }
             client.send_buf.extend_from_slice(&msg);
             flush_ids.push(id);
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -138,8 +138,7 @@ impl Server {
                 }
             }
 
-            self.poll
-                .poll(&mut events, Some(poll_timeout))?;
+            self.poll.poll(&mut events, Some(poll_timeout))?;
 
             for event in events.iter() {
                 match event.token() {
@@ -198,10 +197,7 @@ impl Server {
                 // the vt state is up-to-date.
                 self.flush_pty_output();
                 for id in pending_ids {
-                    log::info!(
-                        "Client {} snapshot deadline expired, sending snapshot",
-                        id
-                    );
+                    log::info!("Client {} snapshot deadline expired, sending snapshot", id);
                     self.send_snapshot_to_client(id);
                 }
             }
@@ -249,8 +245,8 @@ impl Server {
 
                     log::info!("Client {} connected to '{}'", id, self.session.name);
 
-                    let deadline = Instant::now()
-                        + std::time::Duration::from_millis(SNAPSHOT_DEFER_MS);
+                    let deadline =
+                        Instant::now() + std::time::Duration::from_millis(SNAPSHOT_DEFER_MS);
 
                     self.clients.insert(
                         id,
@@ -285,7 +281,8 @@ impl Server {
         if let Err(e) = self.flush_client_send_buf(client_id) {
             log::warn!(
                 "Client {} flush error during snapshot send: {}",
-                client_id, e
+                client_id,
+                e
             );
         }
     }
@@ -345,6 +342,12 @@ impl Server {
         let mut disconnected = Vec::new();
         let mut flush_ids = Vec::new();
         for (&id, client) in self.clients.iter_mut() {
+            // A newly attached client must receive a coherent snapshot first.
+            // Sending live OUTPUT before that can interleave mid-sequence bytes
+            // with snapshot replay and corrupt rendering.
+            if client.pending_snapshot {
+                continue;
+            }
             client.send_buf.extend_from_slice(&msg);
             flush_ids.push(id);
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::io::{self, Read, Write};
 use std::os::unix::fs::FileTypeExt;
 use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 const LISTENER: Token = Token(0);
 const PTY_BASE: Token = Token(0x1000_0000);
@@ -16,6 +16,14 @@ const CLIENT_BASE: Token = Token(0x2000_0000);
 /// This gives the client time to send a RESIZE with its actual window size
 /// so the snapshot is generated at the correct dimensions.
 const SNAPSHOT_DEFER_MS: u64 = 500;
+
+/// Micro-batching constants for PTY output coalescing.
+/// After a read, wait this long before flushing to coalesce nearby writes.
+const BATCH_DELAY_MS: u64 = 1;
+/// Maximum time from the first read in a burst before we force a flush.
+const BATCH_MAX_MS: u64 = 3;
+/// If the pending buffer reaches this size, flush immediately.
+const BATCH_FLUSH_SIZE: usize = 4096;
 
 struct Client {
     stream: UnixStream,
@@ -34,6 +42,14 @@ pub struct Server {
     listener: UnixListener,
     clients: HashMap<usize, Client>,
     next_client_id: usize,
+    /// Accumulated PTY output waiting to be flushed.
+    pending_pty_output: Vec<u8>,
+    /// When the first byte of the current batch arrived.
+    batch_start: Option<Instant>,
+    /// Deadline by which the current batch must be flushed.
+    batch_deadline: Option<Instant>,
+    /// `true` after the EXIT message has been broadcast to clients.
+    exit_sent: bool,
 }
 
 impl Server {
@@ -73,6 +89,10 @@ impl Server {
             listener,
             clients: HashMap::new(),
             next_client_id: 0,
+            pending_pty_output: Vec::new(),
+            batch_start: None,
+            batch_deadline: None,
+            exit_sent: false,
         })
     }
 
@@ -102,8 +122,24 @@ impl Server {
                 }
             }
 
+            // Dynamic poll timeout: use the nearest deadline among the
+            // default 100ms, any pending snapshot deadline, and the batch
+            // flush deadline.
+            let mut poll_timeout = Duration::from_millis(100);
+            if let Some(bd) = self.batch_deadline {
+                let remaining = bd.saturating_duration_since(Instant::now());
+                poll_timeout = poll_timeout.min(remaining);
+            }
+            // Also consider snapshot deadlines.
+            for c in self.clients.values() {
+                if let Some(sd) = c.pending_snapshot_deadline {
+                    let remaining = sd.saturating_duration_since(Instant::now());
+                    poll_timeout = poll_timeout.min(remaining);
+                }
+            }
+
             self.poll
-                .poll(&mut events, Some(std::time::Duration::from_millis(100)))?;
+                .poll(&mut events, Some(poll_timeout))?;
 
             for event in events.iter() {
                 match event.token() {
@@ -132,6 +168,13 @@ impl Server {
                 }
             }
 
+            // Flush pending PTY output if the batch deadline has expired.
+            if let Some(bd) = self.batch_deadline {
+                if Instant::now() >= bd {
+                    self.flush_pty_output();
+                }
+            }
+
             // Send deferred snapshots for clients whose deadline has expired
             // without receiving a RESIZE (backwards compatibility with plain
             // `pterm attach` from a raw terminal).
@@ -150,22 +193,35 @@ impl Server {
                     None
                 })
                 .collect();
-            for id in pending_ids {
-                log::info!(
-                    "Client {} snapshot deadline expired, sending snapshot",
-                    id
-                );
-                self.send_snapshot_to_client(id);
+            if !pending_ids.is_empty() {
+                // Flush any pending PTY output before sending snapshots so
+                // the vt state is up-to-date.
+                self.flush_pty_output();
+                for id in pending_ids {
+                    log::info!(
+                        "Client {} snapshot deadline expired, sending snapshot",
+                        id
+                    );
+                    self.send_snapshot_to_client(id);
+                }
             }
 
-            if let Some(exit_code) = self.session.check_exit() {
-                log::info!("Child exited with code {}", exit_code);
-                let msg = proto::encode(proto::server::EXIT, &exit_code.to_le_bytes());
-                for client in self.clients.values_mut() {
-                    let _ = client.stream.write_all(&msg);
-                }
-                if self.clients.is_empty() {
-                    break;
+            if !self.exit_sent {
+                if let Some(exit_code) = self.session.check_exit() {
+                    // Flush pending output before the EXIT message.
+                    self.flush_pty_output();
+                    log::info!("Child exited with code {}", exit_code);
+
+                    let msg = proto::encode(proto::server::EXIT, &exit_code.to_le_bytes());
+                    for client in self.clients.values_mut() {
+                        client.send_buf.extend_from_slice(&msg);
+                    }
+                    self.flush_all_clients();
+                    self.exit_sent = true;
+
+                    if self.clients.is_empty() {
+                        break;
+                    }
                 }
             }
 
@@ -235,16 +291,23 @@ impl Server {
     }
 
     fn handle_pty_output(&mut self, buf: &mut [u8]) -> io::Result<()> {
-        // Drain all available PTY data into a single buffer so we send one
-        // coalesced OUTPUT message instead of many small fragments.
-        let mut output = Vec::new();
+        // Drain all available PTY data into the pending batch buffer.
+        let mut read_any = false;
         loop {
             match self.session.read_pty(buf) {
                 Ok(0) => break,
-                Ok(n) => output.extend_from_slice(&buf[..n]),
+                Ok(n) => {
+                    read_any = true;
+                    self.pending_pty_output.extend_from_slice(&buf[..n]);
+
+                    // Enforce a hard size cap during draining.
+                    if self.pending_pty_output.len() >= BATCH_FLUSH_SIZE {
+                        self.flush_pty_output();
+                    }
+                }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => break,
                 Err(e) => {
-                    if output.is_empty() {
+                    if self.pending_pty_output.is_empty() {
                         log::error!("pty read error: {}", e);
                     }
                     break;
@@ -252,11 +315,33 @@ impl Server {
             }
         }
 
-        if output.is_empty() {
+        if self.pending_pty_output.is_empty() {
             return Ok(());
         }
 
-        let msg = proto::encode(proto::server::OUTPUT, &output);
+        // Update deadline only when this call actually read new bytes.
+        if read_any {
+            let now = Instant::now();
+            let batch_start = *self.batch_start.get_or_insert(now);
+            let max_deadline = batch_start + Duration::from_millis(BATCH_MAX_MS);
+            let delay_deadline = now + Duration::from_millis(BATCH_DELAY_MS);
+            self.batch_deadline = Some(delay_deadline.min(max_deadline));
+        }
+
+        Ok(())
+    }
+
+    /// Flush accumulated PTY output to all connected clients and reset batch state.
+    fn flush_pty_output(&mut self) {
+        if self.pending_pty_output.is_empty() {
+            return;
+        }
+
+        let msg = proto::encode(proto::server::OUTPUT, &self.pending_pty_output);
+        self.pending_pty_output.clear();
+        self.batch_start = None;
+        self.batch_deadline = None;
+
         let mut disconnected = Vec::new();
         let mut flush_ids = Vec::new();
         for (&id, client) in self.clients.iter_mut() {
@@ -272,7 +357,6 @@ impl Server {
             log::info!("Client {} disconnected", id);
             self.clients.remove(&id);
         }
-        Ok(())
     }
 
     fn set_client_interest(&mut self, client_id: usize, writable: bool) -> io::Result<()> {
@@ -357,6 +441,9 @@ impl Server {
             self.clients.remove(&client_id);
         } else if let Some(client) = self.clients.get_mut(&client_id) {
             if !client.recv_buf.is_empty() {
+                // Flush pending PTY output so the vt state is current before
+                // processing client messages (e.g. REDRAW, RESIZE snapshots).
+                self.flush_pty_output();
                 let needs_flush = self.process_client_recv_buf(client_id)?;
                 if needs_flush {
                     self.flush_all_clients();

--- a/src/session.rs
+++ b/src/session.rs
@@ -22,13 +22,21 @@ impl Session {
     }
 
     /// Read available data from pty, feed to VT parser, return what was read.
+    /// Returns `Err(WouldBlock)` when the non-blocking fd has no more data.
     pub fn read_pty(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let fd = self.pty.master.as_raw_fd();
-        let n = nix::unistd::read(fd, buf).map_err(io::Error::other)?;
-        if n > 0 {
-            self.parser.process(&buf[..n]);
+        match nix::unistd::read(fd, buf) {
+            Ok(n) => {
+                if n > 0 {
+                    self.parser.process(&buf[..n]);
+                }
+                Ok(n)
+            }
+            Err(e) if e == nix::errno::Errno::EAGAIN || e == nix::errno::Errno::EWOULDBLOCK => {
+                Err(io::Error::from(io::ErrorKind::WouldBlock))
+            }
+            Err(e) => Err(io::Error::other(e)),
         }
-        Ok(n)
     }
 
     /// Write input data to pty (forward user keystrokes).


### PR DESCRIPTION
## Summary

- **Coalesce PTY output per poll cycle**: drain all available PTY data into a single OUTPUT message instead of sending many small fragments (`f2fd4f0`)
- **Batch OUTPUT writes in bridge**: apply the same coalescing in the bridge layer (`df5bd42`)
- **Bounded micro-batching**: hold small PTY outputs up to 1ms (max 3ms burst) before flushing to coalesce nearby shell writes; flush immediately when buffer ≥4096 bytes (`165ecc1`)
- **Fix EXIT message ordering**: queue EXIT into `send_buf` (after flushing pending OUTPUT) instead of using direct `write_all`, preserving OUTPUT→EXIT ordering under backpressure
- **Prevent duplicate EXIT broadcast**: add `exit_sent` flag so EXIT is sent exactly once
- **Enforce size bound during drain**: flush mid-loop when buffer exceeds threshold
- **Dynamic poll timeout**: `min(100ms, batch_deadline, snapshot_deadlines)` for responsive flushing

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes
- [ ] Manual: start pterm session in a git repo, verify prompt renders in one piece (not fragmented)
- [ ] Manual: run a command with large output (e.g. `cat` a big file), verify no data loss or ordering issues
- [ ] Manual: detach/reattach and verify REDRAW works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)