### PR TITLE
ci: update CHANGELOG.md on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,31 @@ jobs:
           body: ${{ steps.changelog.outputs.content }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout default branch
+        run: |
+          git fetch origin ${{ github.event.repository.default_branch }}
+          git checkout -B ${{ github.event.repository.default_branch }} origin/${{ github.event.repository.default_branch }}
+
+      - name: Regenerate full changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --output CHANGELOG.md
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Commit and push CHANGELOG.md
+        run: |
+          # see https://github.com/orgs/community/discussions/26560
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "No CHANGELOG.md updates to commit."
+            exit 0
+          fi
+
+          git add CHANGELOG.md
+          git commit -m "chore(release): update CHANGELOG.md"
+          git push origin ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
## Summary
- リリースワークフローにCHANGELOG.md自動更新ステップを追加
- タグpush時にGitHub Release作成後、git-cliffで全履歴のCHANGELOGを再生成しデフォルトブランチにコミット
- コミットメッセージ `chore(release)` はcliff.tomlでスキップ設定済み

## Test plan
- [ ] タグをpushしてワークフローが正常に完了することを確認
- [ ] GitHub Releaseが作成されることを確認
- [ ] CHANGELOG.mdがデフォルトブランチに更新コミットされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)