### PR TITLE
fix: prevent duplicate rendering when attaching via :Pterm

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ require("pterm").setup({
   binary = nil,
   -- Default shell command
   shell = vim.env.SHELL or "/bin/sh",
-  -- Fallback terminal size (Neovim window size takes priority)
+  -- Default terminal size for `pterm new` when created outside Neovim
+  -- (the bridge reads the actual PTY size via TIOCGWINSZ at attach time)
   cols = 80,
   rows = 24,
   -- Socket directory (nil = let daemon decide)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -78,7 +78,7 @@ Notable behavior:
 - session socket path: `<socket_root>/<session>/socket`
 - if socket file is removed externally, daemon treats session as deleted and exits
 - output delivery uses per-client send queues and writable polling to avoid disconnecting on backpressure (`WouldBlock`)
-- **snapshot delivery**: no timer-based deferral; snapshot is sent either when the client sends RESIZE (correct dimensions) or when the first PTY OUTPUT arrives (current dimensions as fallback)
+- **snapshot delivery**: no timer-based deferral; snapshot is sent either when the client sends RESIZE (correct dimensions) or when the first PTY OUTPUT arrives (current dimensions as fallback). Clients that receive a snapshot are excluded from the same flush cycle's OUTPUT broadcast to prevent duplicate rendering (the snapshot already reflects the effect of those bytes)
 - **drain-and-flush**: PTY output uses non-blocking drain (reads until `WouldBlock`) followed by immediate flush — no timer-based micro-batching, minimizing latency while naturally coalescing bytes available at each poll cycle
 - EXIT message is queued into `send_buf` (not written directly) to preserve OUTPUT→EXIT ordering under backpressure, and is sent exactly once via an `exit_sent` guard
 

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -174,17 +174,17 @@ function M.open(session_name, args)
 			end
 		end
 
-		local win_cols = vim.api.nvim_win_get_width(0)
-		local win_rows = vim.api.nvim_win_get_height(0)
-
+		-- Do NOT pass --cols/--rows to `pterm new` here.  The bridge
+		-- (started by M.attach) will send an accurate RESIZE based on
+		-- the actual PTY size after terminal-friendly window options
+		-- (number=false, signcolumn=no, …) have been applied.  Passing
+		-- dimensions at this point would use the pre-option window size,
+		-- which may differ and trigger an unnecessary resize + snapshot
+		-- race on the daemon side.
 		local create_cmd = {
 			bin,
 			"new",
 			session_name,
-			"--cols",
-			tostring(win_cols),
-			"--rows",
-			tostring(win_rows),
 		}
 
 		if #cmd_parts > 0 then
@@ -249,15 +249,13 @@ function M.attach(session_name)
 	vim.api.nvim_set_option_value("foldcolumn", "0", { win = win })
 	vim.api.nvim_set_option_value("statuscolumn", "", { win = win })
 
-	-- Pass the current window size so the bridge sends an accurate initial
-	-- RESIZE before the daemon generates the snapshot.
-	local win_cols = vim.api.nvim_win_get_width(win)
-	local win_rows = vim.api.nvim_win_get_height(win)
-
+	-- Let the bridge read the actual PTY size via TIOCGWINSZ instead of
+	-- passing --cols/--rows from Lua.  jobstart({term=true}) creates a PTY
+	-- sized to the current window, and the bridge's get_winsize(stdout)
+	-- will return exactly that size.  This avoids any mismatch between the
+	-- Lua-reported dimensions and the real PTY geometry.
 	local job_id = vim.fn.jobstart({
 		bin, "attach", session_name,
-		"--cols", tostring(win_cols),
-		"--rows", tostring(win_rows),
 	}, {
 		term = true,
 		on_exit = function(_, exit_code, _)

--- a/src/server.rs
+++ b/src/server.rs
@@ -253,17 +253,22 @@ impl Server {
 
         // Clients awaiting snapshot: the arrival of OUTPUT means the VT state
         // is populated, so send their snapshot now (no timer needed).
+        // These clients must NOT also receive the raw OUTPUT bytes below,
+        // because the snapshot already reflects the effect of those bytes
+        // (read_pty feeds data to the VT parser before this method runs).
+        // Sending both would cause Neovim's libvterm to process the same
+        // content twice, resulting in duplicated rendering.
         let snapshot_ids: Vec<usize> = self
             .clients
             .iter()
             .filter_map(|(&id, c)| if c.pending_snapshot { Some(id) } else { None })
             .collect();
-        for id in snapshot_ids {
+        for id in &snapshot_ids {
             log::info!(
                 "Client {} snapshot triggered by PTY output arrival",
-                id
+                *id
             );
-            self.send_snapshot_to_client(id);
+            self.send_snapshot_to_client(*id);
         }
 
         let msg = proto::encode(proto::server::OUTPUT, &self.pending_pty_output);
@@ -272,6 +277,11 @@ impl Server {
         let mut disconnected = Vec::new();
         let mut flush_ids = Vec::new();
         for (&id, client) in self.clients.iter_mut() {
+            // Skip clients that just received a snapshot — they already have
+            // the up-to-date screen state and must not get the raw bytes again.
+            if snapshot_ids.contains(&id) {
+                continue;
+            }
             client.send_buf.extend_from_slice(&msg);
             flush_ids.push(id);
         }


### PR DESCRIPTION
## Summary

- **server.rs**: `flush_pty_output()` でスナップショットを送信したクライアントに対して、同じflushサイクルのOUTPUTブロードキャストをスキップするよう修正。スナップショットは既にそれらのバイトの効果を含んでいるため、二重送信はNeovimのlibvtermで同じ内容が2回処理され、描画が重複していた（例: "e" → "ee" → "eechooo"）
- **init.lua**: `pterm new` と `pterm attach` に `--cols/--rows` を渡すのをやめ、ブリッジが `TIOCGWINSZ` で実際のPTYサイズを取得するよう変更。toggletermと同じ動作に統一し、ウィンドウオプション設定前後のサイズ不一致を解消
- **README.md / DESIGN.md**: 上記変更を反映したドキュメント更新

## Root Cause

`flush_pty_output()` で `pending_snapshot=true` のクライアントにスナップショットを送信した直後、全クライアント（スナップショット受信者含む）にOUTPUT生バイトも送信していた。`read_pty()` がVTパーサーにバイトを事前に処理させているため、スナップショットにはOUTPUTバイトの効果が既に含まれており、Neovimのlibvtermで同じ内容が二重処理されていた。

toggletermでは `pterm open` がデーモン作成とブリッジ接続を同一プロセスで行うため、シェルのPTY出力が到達する前にRESIZEが処理され、このレースが発生しなかった。

## Test plan

- [ ] `:Pterm` コマンドで新規セッションを作成し、文字入力時に描画の重複がないことを確認
- [ ] toggleterm経由での `pterm open` が引き続き正常に動作することを確認
- [ ] 既存セッションへの再アタッチ時にスナップショットが正しく表示されることを確認
- [ ] ウィンドウリサイズ時に正しくリサイズが伝播されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)