### PR TITLE
fix: defer BufDelete handler to ignore buflisted changes from scope-nvim

### DIFF
--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -184,12 +184,21 @@ local function start_terminal(session_name, cmd)
 	local augroup_name = "pterm_" .. session_name:gsub("/", "_")
 	local augroup = vim.api.nvim_create_augroup(augroup_name, { clear = true })
 
-	-- Clean up on buffer delete
+	-- Clean up on buffer delete.
+	-- BufDelete fires both when a buffer is truly deleted (:bdelete/:bwipeout)
+	-- and when a plugin merely sets buflisted=false (e.g. scope-nvim scopes
+	-- buffers per tab page).  Defer the check so we can distinguish the two:
+	-- a merely-unlisted buffer remains valid and loaded.
 	vim.api.nvim_create_autocmd("BufDelete", {
 		group = augroup,
 		buffer = buf,
 		callback = function()
-			M.detach(session_name)
+			vim.schedule(function()
+				if vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_is_loaded(buf) then
+					return
+				end
+				M.detach(session_name)
+			end)
 		end,
 	})
 


### PR DESCRIPTION
## Summary
- **原因**: scope-nvim がタブ切り替え時に `buflisted=false` を設定 → `BufDelete` 発火 → pterm の `M.detach()` が bridge を kill → ターミナル消滅
- **修正**: `BufDelete` コールバックを `vim.schedule` で遅延させ、バッファが `valid` かつ `loaded` なら（単なる unlisting）detach をスキップ。真の削除（`:bdelete`/`:bwipeout`）時のみ detach を実行

## Root cause
scope-nvim scopes buffers per tab page by toggling `buflisted` on `TabLeave`/`TabEnter`. Setting `buflisted=false` fires `BufDelete`, which pterm interpreted as true buffer deletion — calling `M.detach()`, killing the bridge (SIGHUP exit code 129), and wiping the buffer.

Built-in `:terminal` is unaffected because it has no `BufDelete` autocmd handler.

## Test plan
- [x] `:Pterm` → `:tabnew` → `:tabprev` でターミナルが正しく表示されることを確認
- [x] `:Pterm` → `:bdelete!` でバッファが正しく削除・detach されることを確認
- [x] `:Pterm` → シェルで `exit` → `:bdelete` で正しくクリーンアップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)