### PR TITLE
debug: instrument VT pipeline for ANSI display investigation

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -15,6 +15,10 @@ use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+fn esc_count(bytes: &[u8]) -> usize {
+    bytes.iter().filter(|&&b| b == 0x1b).count()
+}
+
 const TOKEN_STDIN: Token = Token(0);
 const TOKEN_SOCKET: Token = Token(1);
 const TOKEN_WAKE: Token = Token(2);
@@ -103,6 +107,10 @@ fn write_all_raw(fd: RawFd, data: &[u8]) -> io::Result<()> {
 /// `initial_cols` / `initial_rows` override the terminal size sent in the
 /// initial RESIZE message.  When `None`, the size is read from `TIOCGWINSZ`
 /// (stdout) with a final fallback to 80×24.
+///
+/// When the `PTERM_DEBUG_OUTPUT` environment variable is set to a file path,
+/// all bytes written to stdout (i.e. Neovim's terminal) are also appended to
+/// that file for offline analysis.
 pub fn run(
     socket_path: &Path,
     initial_cols: Option<u16>,
@@ -110,6 +118,28 @@ pub fn run(
 ) -> io::Result<i32> {
     let stdin_fd = libc::STDIN_FILENO;
     let stdout_fd = libc::STDOUT_FILENO;
+
+    // Optional debug log for output bytes.
+    let mut debug_output: Option<std::fs::File> = std::env::var("PTERM_DEBUG_OUTPUT")
+        .ok()
+        .map(|path| {
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .expect("failed to open PTERM_DEBUG_OUTPUT file")
+        });
+
+    // Optional debug log for protocol frame events (type, size, esc count).
+    let mut debug_frames: Option<std::fs::File> = std::env::var("PTERM_DEBUG_FRAMES")
+        .ok()
+        .map(|path| {
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .expect("failed to open PTERM_DEBUG_FRAMES file")
+        });
 
     // Enter raw mode on stdin (if it's a terminal)
     let _raw_guard = if unsafe { libc::isatty(stdin_fd) } == 1 {
@@ -253,6 +283,20 @@ pub fn run(
                         let payload = &recv_buf[offset..offset + payload_len];
                         offset += payload_len;
 
+                        if let Some(ref mut f) = debug_frames {
+                            let kind = match msg_type {
+                                proto::server::OUTPUT => "OUTPUT",
+                                proto::server::SCROLLBACK => "SCROLLBACK",
+                                proto::server::EXIT => "EXIT",
+                                _ => "OTHER",
+                            };
+                            let _ = writeln!(
+                                f,
+                                "[frame] type={kind} len={payload_len} esc={}",
+                                esc_count(payload)
+                            );
+                        }
+
                         match msg_type {
                             proto::server::OUTPUT | proto::server::SCROLLBACK => {
                                 output_batch.extend_from_slice(payload);
@@ -264,6 +308,17 @@ pub fn run(
                                 }
                                 // Flush any batched output before exiting
                                 if !output_batch.is_empty() {
+                                    if let Some(ref mut f) = debug_frames {
+                                        let _ = writeln!(
+                                            f,
+                                            "[stdout_write] len={} esc={}",
+                                            output_batch.len(),
+                                            esc_count(&output_batch)
+                                        );
+                                    }
+                                    if let Some(ref mut f) = debug_output {
+                                        let _ = f.write_all(&output_batch);
+                                    }
                                     let _ = write_all_raw(stdout_fd, &output_batch);
                                 }
                                 break 'main;
@@ -273,6 +328,17 @@ pub fn run(
                     }
 
                     if !output_batch.is_empty() {
+                        if let Some(ref mut f) = debug_frames {
+                            let _ = writeln!(
+                                f,
+                                "[stdout_write] len={} esc={}",
+                                output_batch.len(),
+                                esc_count(&output_batch)
+                            );
+                        }
+                        if let Some(ref mut f) = debug_output {
+                            let _ = f.write_all(&output_batch);
+                        }
                         if write_all_raw(stdout_fd, &output_batch).is_err() {
                             break 'main;
                         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,6 +8,22 @@ use std::os::unix::fs::FileTypeExt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+fn esc_count(bytes: &[u8]) -> usize {
+    bytes.iter().filter(|&&b| b == 0x1b).count()
+}
+
+fn dbg_daemon(msg: &str) {
+    if let Ok(path) = std::env::var("PTERM_DEBUG_DAEMON") {
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            let _ = writeln!(f, "{msg}");
+        }
+    }
+}
+
 const LISTENER: Token = Token(0);
 const PTY_BASE: Token = Token(0x1000_0000);
 const CLIENT_BASE: Token = Token(0x2000_0000);
@@ -200,6 +216,11 @@ impl Server {
     /// pending-snapshot flag.
     fn send_snapshot_to_client(&mut self, client_id: usize) {
         let snapshot = self.session.snapshot();
+        dbg_daemon(&format!(
+            "[send_snapshot] client={client_id} len={} esc={}",
+            snapshot.len(),
+            esc_count(&snapshot)
+        ));
         if let Some(client) = self.clients.get_mut(&client_id) {
             client.pending_snapshot = false;
             if !snapshot.is_empty() {
@@ -263,6 +284,12 @@ impl Server {
             .iter()
             .filter_map(|(&id, c)| if c.pending_snapshot { Some(id) } else { None })
             .collect();
+        dbg_daemon(&format!(
+            "[flush_pty] raw_len={} raw_esc={} snapshot_clients={snapshot_ids:?} total_clients={}",
+            self.pending_pty_output.len(),
+            esc_count(&self.pending_pty_output),
+            self.clients.len()
+        ));
         for id in &snapshot_ids {
             log::info!(
                 "Client {} snapshot triggered by PTY output arrival",
@@ -427,6 +454,9 @@ impl Server {
                         // If this client still has a pending snapshot, the
                         // session has now been resized to the correct
                         // dimensions.  Generate and send the snapshot.
+                        dbg_daemon(&format!(
+                            "[resize] client={client_id} cols={cols} rows={rows}"
+                        ));
                         let needs_snapshot = self
                             .clients
                             .get(&client_id)

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,6 +1,23 @@
 use crate::pty::Pty;
 use std::io;
+use std::io::Write as _;
 use std::os::fd::AsRawFd;
+
+fn esc_count(bytes: &[u8]) -> usize {
+    bytes.iter().filter(|&&b| b == 0x1b).count()
+}
+
+fn dbg_daemon(msg: &str) {
+    if let Ok(path) = std::env::var("PTERM_DEBUG_DAEMON") {
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            let _ = writeln!(f, "{msg}");
+        }
+    }
+}
 
 pub struct Session {
     pub name: String,
@@ -29,6 +46,14 @@ impl Session {
             Ok(n) => {
                 if n > 0 {
                     self.parser.process(&buf[..n]);
+                    let s = self.parser.screen();
+                    let (rows, cols) = s.size();
+                    let (cur_row, cur_col) = s.cursor_position();
+                    dbg_daemon(&format!(
+                        "[read_pty] n={n} esc={} size={cols}x{rows} cursor=({cur_col},{cur_row}) errors={}",
+                        esc_count(&buf[..n]),
+                        s.errors()
+                    ));
                 }
                 Ok(n)
             }
@@ -70,7 +95,17 @@ impl Session {
 
     /// Generate escape sequences that reproduce the current terminal state.
     pub fn snapshot(&self) -> Vec<u8> {
-        self.parser.screen().state_formatted()
+        let s = self.parser.screen();
+        let snap = s.state_formatted();
+        let (rows, cols) = s.size();
+        let wrapped: Vec<u16> = (0..rows).filter(|&r| s.row_wrapped(r)).take(32).collect();
+        dbg_daemon(&format!(
+            "[snapshot] len={} esc={} size={cols}x{rows} cursor={:?} wrapped={wrapped:?}",
+            snap.len(),
+            esc_count(&snap),
+            s.cursor_position()
+        ));
+        snap
     }
 
     /// Get the master fd for polling.


### PR DESCRIPTION
## Summary

- ANSIエスケープシーケンス（色付き出力）使用時に改行位置がズレる問題の原因調査用デバッグログを追加
- 3つの環境変数でログ出力先ファイルを制御（本番では無効）

## 追加したログ

| 環境変数 | 出力内容 |
|---|---|
| `PTERM_DEBUG_DAEMON` | daemon側: `read_pty`のパーサ状態（n, ESC数, cursor, errors）、`snapshot`の統計（len, ESC数, wrapped行）、`send_snapshot` / `flush_pty` / `resize` |
| `PTERM_DEBUG_FRAMES` | bridge側: protocol frameのdecode（type, len, ESC数）、stdoutへの書き込みバッチ（len, ESC数） |
| `PTERM_DEBUG_OUTPUT` | Neovim stdoutへ書き込んだ生バイト（既存） |

## 使い方

```bash
PTERM_DEBUG_DAEMON=/tmp/pterm_daemon.log \
PTERM_DEBUG_FRAMES=/tmp/pterm_frames.log \
PTERM_DEBUG_OUTPUT=/tmp/pterm_output.bin \
  nix run .#test-nvim
```

調査後はこのブランチを削除またはログコードをstrip予定。

## Test plan

- [ ] `nix run .#test-nvim` でNeovimが起動する
- [ ] 色付き出力を発生させる（例: `claude yes`）
- [ ] `PTERM_DEBUG_DAEMON` ログで `[snapshot] wrapped=` に異常な行がないか確認
- [ ] `[read_pty] errors=` でvt100パーサエラーが出ていないか確認
- [ ] `PTERM_DEBUG_FRAMES` ログでOUTPUT/SCROLLBACKのESC数を比較

🤖 Generated with [Claude Code](https://claude.com/claude-code)