### PR TITLE
fix: update vt100 0.15 → 0.16 to restore dim (SGR 2) attribute in snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,9 +340,9 @@ checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"
@@ -352,35 +352,23 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vt100"
-version = "0.15.2"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
 dependencies = [
  "itoa",
- "log",
  "unicode-width",
  "vte",
 ]
 
 [[package]]
 name = "vte"
-version = "0.11.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
-dependencies = [
- "proc-macro2",
- "quote",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4"
 env_logger = "0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-vt100 = "0.15"
+vt100 = "0.16"
 
 [workspace]
 members = ["proto"]

--- a/src/session.rs
+++ b/src/session.rs
@@ -64,7 +64,7 @@ impl Session {
     /// Resize the pty and VT parser.
     pub fn resize(&mut self, cols: u16, rows: u16) -> io::Result<()> {
         self.pty.resize(cols, rows)?;
-        self.parser.set_size(rows, cols);
+        self.parser.screen_mut().set_size(rows, cols);
         Ok(())
     }
 


### PR DESCRIPTION
## 問題

detach → re-attach 時に `dim`/`faint` テキスト（SGR 2）の属性が消える。

```
ライブ出力:  ESC[2mNo ESC[0m   → faint 表示
snapshot:    ESC[m  No          → 通常テキストとして表示（属性消失）
```

`claude yes` のような yes/no ダイアログで "No" が faint にならない現象の原因。

## 原因

vt100 0.15 は `dim` 属性を完全未実装:
- `attrs.rs` に `TEXT_MODE_DIM` ビットなし
- `sgr()` ハンドラに `&[2]` ケースなし → SGR 2 受信時に無視
- `state_formatted()` は dim を再生成しない

## 修正

vt100 0.16 へ更新。0.16 での変更:
- `TEXT_MODE_DIM = 0b0000_0010` を追加
- `sgr()` に `[2] => self.attrs.set_dim()` を追加
- `state_formatted()` が `Intensity::Dim` → `ESC[2m` として正しく再出力

## API 変更対応

| 変更前 | 変更後 |
|--------|--------|
| `screen.errors()` | 削除（廃止）→ デバッグログから除去 |
| `parser.set_size(rows, cols)` | `parser.screen_mut().set_size(rows, cols)` |

## 確認方法

byte-level 比較で修正を確認済み（調査ブランチ `debug/display-investigation` #15 参照）:

```
ORIGINAL:   ESC[2mNo ESC[0m  ← faint
0.15 snap:  ESC[m  No        ← dim 消失
0.16 snap:  ESC[m  ESC[2mNo  ← dim 保持
```

## Test plan

- [ ] `nix run .#test-nvim` で起動
- [ ] `printf '\033[2mfaint text\033[0m\n'` を実行
- [ ] detach → re-attach 後も faint 表示が維持されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)