### PR TITLE
fix: improve session snapshot and terminal lifecycle management

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -18,6 +18,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 const TOKEN_STDIN: Token = Token(0);
 const TOKEN_SOCKET: Token = Token(1);
 const TOKEN_WAKE: Token = Token(2);
+const DETACH_CLEANUP_SEQUENCES: &[u8] =
+    b"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l\x1b[?1049l\x1b[?25h";
 
 static SIGWINCH_RECEIVED: AtomicBool = AtomicBool::new(false);
 
@@ -311,6 +313,7 @@ pub fn run(
     // Send DETACH before exiting
     let msg = proto::encode(proto::client::DETACH, &[]);
     let _ = socket.write_all(&msg);
+    let _ = write_all_raw(stdout_fd, DETACH_CLEANUP_SEQUENCES);
 
     Ok(exit_code)
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,8 +11,8 @@ use std::time::Duration;
 const LISTENER: Token = Token(0);
 const PTY_BASE: Token = Token(0x1000_0000);
 const CLIENT_BASE: Token = Token(0x2000_0000);
-const DA1_RESPONSE: &[u8] = b"\x1b[?62;22c";
-const DA2_RESPONSE: &[u8] = b"\x1b[>1;10;0c";
+const DA1_RESPONSE: &[u8] = b"\x1b[?62;22c"; // Primary Device Attributes (DA1)
+const DA2_RESPONSE: &[u8] = b"\x1b[>1;10;0c"; // Secondary Device Attributes (DA2)
 
 struct Client {
     stream: UnixStream,
@@ -282,10 +282,7 @@ impl Server {
             .filter_map(|(&id, c)| if c.pending_snapshot { Some(id) } else { None })
             .collect();
         for id in &snapshot_ids {
-            log::info!(
-                "Client {} snapshot triggered by PTY output arrival",
-                *id
-            );
+            log::info!("Client {} snapshot triggered by PTY output arrival", *id);
             self.send_snapshot_to_client(*id);
         }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,6 +11,8 @@ use std::time::Duration;
 const LISTENER: Token = Token(0);
 const PTY_BASE: Token = Token(0x1000_0000);
 const CLIENT_BASE: Token = Token(0x2000_0000);
+const DA1_RESPONSE: &[u8] = b"\x1b[?62;22c";
+const DA2_RESPONSE: &[u8] = b"\x1b[>1;10;0c";
 
 struct Client {
     stream: UnixStream,
@@ -231,6 +233,22 @@ impl Server {
                     if self.pending_pty_output.is_empty() {
                         log::error!("pty read error: {}", e);
                     }
+                    break;
+                }
+            }
+        }
+
+        let (pending_da1, pending_da2) = self.session.take_pending_da_queries();
+        if self.clients.is_empty() {
+            for _ in 0..pending_da1 {
+                if let Err(e) = self.session.write_pty(DA1_RESPONSE) {
+                    log::warn!("Failed to write DA1 response to PTY: {}", e);
+                    break;
+                }
+            }
+            for _ in 0..pending_da2 {
+                if let Err(e) = self.session.write_pty(DA2_RESPONSE) {
+                    log::warn!("Failed to write DA2 response to PTY: {}", e);
                     break;
                 }
             }

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,10 +2,57 @@ use crate::pty::Pty;
 use std::io;
 use std::os::fd::AsRawFd;
 
+#[derive(Default)]
+struct SessionCallbacks {
+    window_title: Option<String>,
+    pending_da1_queries: usize,
+    pending_da2_queries: usize,
+}
+
+impl SessionCallbacks {
+    fn default_da_params(params: &[&[u16]]) -> bool {
+        params.is_empty()
+            || (params.len() == 1
+                && (params[0].is_empty() || (params[0].len() == 1 && params[0][0] == 0)))
+    }
+
+    fn take_pending_da_queries(&mut self) -> (usize, usize) {
+        let counts = (self.pending_da1_queries, self.pending_da2_queries);
+        self.pending_da1_queries = 0;
+        self.pending_da2_queries = 0;
+        counts
+    }
+}
+
+impl vt100::Callbacks for SessionCallbacks {
+    fn set_window_title(&mut self, _: &mut vt100::Screen, title: &[u8]) {
+        self.window_title = Some(String::from_utf8_lossy(title).into_owned());
+    }
+
+    fn unhandled_csi(
+        &mut self,
+        _: &mut vt100::Screen,
+        i1: Option<u8>,
+        i2: Option<u8>,
+        params: &[&[u16]],
+        c: char,
+    ) {
+        if c != 'c' || i2.is_some() || !Self::default_da_params(params) {
+            return;
+        }
+
+        match i1 {
+            None => self.pending_da1_queries += 1,
+            Some(b'>') => self.pending_da2_queries += 1,
+            _ => {}
+        }
+    }
+}
+
 pub struct Session {
     pub name: String,
     pub pty: Pty,
-    parser: vt100::Parser,
+    parser: vt100::Parser<SessionCallbacks>,
     pub exited: Option<i32>,
 }
 
@@ -16,7 +63,12 @@ impl Session {
         Ok(Self {
             name,
             pty,
-            parser: vt100::Parser::new(rows, cols, 0),
+            parser: vt100::Parser::new_with_callbacks(
+                rows,
+                cols,
+                10_000,
+                SessionCallbacks::default(),
+            ),
             exited: None,
         })
     }
@@ -70,7 +122,28 @@ impl Session {
 
     /// Generate escape sequences that reproduce the current terminal state.
     pub fn snapshot(&self) -> Vec<u8> {
-        self.parser.screen().state_formatted()
+        let mut snapshot = self.parser.screen().state_formatted();
+        let mut prefix = Vec::new();
+
+        if let Some(title) = self.parser.callbacks().window_title.as_ref() {
+            prefix.extend_from_slice(b"\x1b]2;");
+            prefix.extend_from_slice(title.as_bytes());
+            prefix.extend_from_slice(b"\x1b\\");
+        }
+        if self.parser.screen().alternate_screen() {
+            prefix.extend_from_slice(b"\x1b[?1049h");
+        }
+
+        if prefix.is_empty() {
+            snapshot
+        } else {
+            prefix.append(&mut snapshot);
+            prefix
+        }
+    }
+
+    pub fn take_pending_da_queries(&mut self) -> (usize, usize) {
+        self.parser.callbacks_mut().take_pending_da_queries()
     }
 
     /// Get the master fd for polling.


### PR DESCRIPTION
## Summary

- detach 時にクライアント端末へクリーンアップシーケンスを送出（マウスモード・bracketed paste・alt screen・カーソル表示のリセット）
- scrollback 容量を `0 → 10,000` 行に変更し、再アタッチ後に履歴を参照可能に
- クライアント未接続中に DA1/DA2 クエリへ応答を返し、アプリが capability detection でハングするのを防止
- alt screen がアクティブな状態でスナップショットを送る際、先頭に `ESC[?1049h` を付加し再アタッチ後に正しく alt screen へ入るように修正
- ウィンドウタイトルをトラッキングし、スナップショットで `OSC 2` を再送して reattach 後にタイトルを復元

## Test plan

- [x] 通常セッション（alt screen なし）で detach → reattach してスナップショットが正常に再現されることを確認
- [x] `vim` / `htop` 等 alt screen を使うアプリで detach → reattach して画面が正しく復元されることを確認
- [x] detach 後にクライアント端末のマウス・カーソルが正常な状態に戻ることを確認
- [ ] ウィンドウタイトルを設定するアプリで reattach 後にタイトルが復元されることを確認
- [x] `cargo build` が通ること（CI）

🤖 Generated with [Claude Code](https://claude.com/claude-code)