### PR TITLE
Split release prep from tag release

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,0 +1,44 @@
+name: release-prep
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version without the leading v
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-prep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Regenerate full changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --tag v${{ inputs.version }} --output CHANGELOG.md
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Create release prep pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          base: ${{ github.event.repository.default_branch }}
+          branch: release/v${{ inputs.version }}
+          title: chore(release): prepare v${{ inputs.version }}
+          commit-message: chore(release): prepare v${{ inputs.version }}
+          body: |
+            ## Summary
+            - regenerate `CHANGELOG.md` for `v${{ inputs.version }}`
+            - prepare the repository state for tagging `v${{ inputs.version }}`
+            - keep release metadata changes on the normal PR review path

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -46,17 +47,15 @@ jobs:
         env:
           GITHUB_REPO: ${{ github.repository }}
 
-      - name: Commit and push CHANGELOG.md
-        run: |
-          # see https://github.com/orgs/community/discussions/26560
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          if git diff --quiet -- CHANGELOG.md; then
-            echo "No CHANGELOG.md updates to commit."
-            exit 0
-          fi
-
-          git add CHANGELOG.md
-          git commit -m "chore(release): update CHANGELOG.md"
-          git push origin ${{ github.event.repository.default_branch }}
+      - name: Create changelog update pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          base: ${{ github.event.repository.default_branch }}
+          branch: chore/release-changelog-${{ github.ref_name }}
+          title: chore(release): update CHANGELOG.md for ${{ github.ref_name }}
+          commit-message: chore(release): update CHANGELOG.md for ${{ github.ref_name }}
+          body: |
+            ## Summary
+            - regenerate `CHANGELOG.md` for `${{ github.ref_name }}`
+            - avoid pushing directly to `${{ github.event.repository.default_branch }}`
+            - keep the release workflow aligned with the repository's PR-first policy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   release:
@@ -33,29 +32,3 @@ jobs:
           body: ${{ steps.changelog.outputs.content }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout default branch
-        run: |
-          git fetch origin ${{ github.event.repository.default_branch }}
-          git checkout -B ${{ github.event.repository.default_branch }} origin/${{ github.event.repository.default_branch }}
-
-      - name: Regenerate full changelog
-        uses: orhun/git-cliff-action@v4
-        with:
-          config: cliff.toml
-          args: --output CHANGELOG.md
-        env:
-          GITHUB_REPO: ${{ github.repository }}
-
-      - name: Create changelog update pull request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          base: ${{ github.event.repository.default_branch }}
-          branch: chore/release-changelog-${{ github.ref_name }}
-          title: chore(release): update CHANGELOG.md for ${{ github.ref_name }}
-          commit-message: chore(release): update CHANGELOG.md for ${{ github.ref_name }}
-          body: |
-            ## Summary
-            - regenerate `CHANGELOG.md` for `${{ github.ref_name }}`
-            - avoid pushing directly to `${{ github.event.repository.default_branch }}`
-            - keep the release workflow aligned with the repository's PR-first policy


### PR DESCRIPTION
## Summary
- add a separate `release-prep.yml` workflow that creates a release preparation PR from a manually supplied version
- simplify `release.yml` so tag pushes only create the GitHub Release and do not mutate the repository
- keep `CHANGELOG.md` updates on the normal PR review path instead of generating them after release

## Release flow after this change
1. Run `release-prep.yml` with a version like `0.2.4`
2. Review and merge the generated release prep PR
3. Tag the resulting merge commit as `v0.2.4`
4. Let `release.yml` create the GitHub Release from that tag

## Why
The previous release workflow still treated changelog updates as a post-release concern. That avoided direct pushes to the default branch, but it kept the release pipeline split across tagging and a follow-up changelog PR.

This change makes `main` the source of truth for release metadata before tagging, which is more consistent with a PR-first repository policy.

Closes #19

## Testing
- reviewed workflow YAML locally
- verified `git-cliff --tag vX.Y.Z --output CHANGELOG.md` behavior locally