### PR TITLE
fix: quote colon-containing strings in release-prep workflow

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -35,8 +35,8 @@ jobs:
         with:
           base: ${{ github.event.repository.default_branch }}
           branch: release/v${{ inputs.version }}
-          title: chore(release): prepare v${{ inputs.version }}
-          commit-message: chore(release): prepare v${{ inputs.version }}
+          title: "chore(release): prepare v${{ inputs.version }}"
+          commit-message: "chore(release): prepare v${{ inputs.version }}"
           body: |
             ## Summary
             - regenerate `CHANGELOG.md` for `v${{ inputs.version }}`


### PR DESCRIPTION
## Summary

- `.github/workflows/release-prep.yml` の38・39行目で `:` を含む文字列がクォートなしで書かれていたYAML構文エラーを修正
- `title` と `commit-message` の値をダブルクォートで囲むことで修正

## Root Cause

YAMLでは値に `:` が含まれる場合、クォートが必要。以下の行が原因:
```yaml
title: chore(release): prepare v${{ inputs.version }}
commit-message: chore(release): prepare v${{ inputs.version }}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)