### PR TITLE
fix: use GitHub App token for release prep PR creation

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -30,9 +30,17 @@ jobs:
         env:
           GITHUB_REPO: ${{ github.repository }}
 
-      - name: Create release prep pull request
-        uses: peter-evans/create-pull-request@v7
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
         with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Create release prep pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
           base: ${{ github.event.repository.default_branch }}
           branch: release/v${{ inputs.version }}
           title: "chore(release): prepare v${{ inputs.version }}"


### PR DESCRIPTION
## Summary

- `actions/create-github-app-token@v2` でGitHub Appのトークンを生成し、`create-pull-request` に渡すことでCIワークフローがトリガーされるよう修正
- `peter-evans/create-pull-request` を v7 → v8 に更新（Node.js 24対応）

## Background

`GITHUB_TOKEN` で作成したPRは他のワークフローをトリガーしないGitHubの制限があるため、GitHub Appのトークンを使用する方式に変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)