### PR TITLE
fix: allow ttak0422-bot in claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "ttak0422-bot"
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary

- `claude-code-review.yml` に `allowed_bots: "ttak0422-bot"` を追加
- GitHub App（ttak0422-bot）が作成したPRでもClaudeコードレビューが実行されるよう修正

## Background

GitHub Appトークンで作成したPRでCIをトリガーする対応（#26）により、`ttak0422-bot` がPRを作成するようになった。しかし `claude-code-review` アクションがBotによる起動をデフォルトで拒否するため、`allowed_bots` への追加が必要だった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)