### PR TITLE
fix: preserve unhandled OSC/CSI/escape sequences in snapshots

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -7,9 +7,14 @@ struct SessionCallbacks {
     window_title: Option<String>,
     pending_da1_queries: usize,
     pending_da2_queries: usize,
+    passthrough_sequences: Vec<Vec<u8>>,
+    passthrough_bytes: usize,
 }
 
 impl SessionCallbacks {
+    const MAX_PASSTHROUGH_SEQUENCES: usize = 256;
+    const MAX_PASSTHROUGH_BYTES: usize = 16 * 1024;
+
     fn default_da_params(params: &[&[u16]]) -> bool {
         params.is_empty()
             || (params.len() == 1
@@ -21,6 +26,99 @@ impl SessionCallbacks {
         self.pending_da1_queries = 0;
         self.pending_da2_queries = 0;
         counts
+    }
+
+    fn push_passthrough_sequence(&mut self, seq: Vec<u8>) {
+        if seq.is_empty() {
+            return;
+        }
+
+        self.passthrough_bytes += seq.len();
+        self.passthrough_sequences.push(seq);
+
+        while self.passthrough_sequences.len() > Self::MAX_PASSTHROUGH_SEQUENCES
+            || self.passthrough_bytes > Self::MAX_PASSTHROUGH_BYTES
+        {
+            let removed = self.passthrough_sequences.remove(0);
+            self.passthrough_bytes -= removed.len();
+        }
+    }
+
+    fn passthrough_sequences_formatted(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(self.passthrough_bytes);
+        for seq in &self.passthrough_sequences {
+            bytes.extend_from_slice(seq);
+        }
+        bytes
+    }
+
+    fn format_unhandled_escape(i1: Option<u8>, i2: Option<u8>, b: u8) -> Vec<u8> {
+        let mut seq = vec![0x1b];
+        if let Some(i1) = i1 {
+            seq.push(i1);
+        }
+        if let Some(i2) = i2 {
+            seq.push(i2);
+        }
+        seq.push(b);
+        seq
+    }
+
+    fn format_unhandled_csi(i1: Option<u8>, i2: Option<u8>, params: &[&[u16]], c: char) -> Vec<u8> {
+        let mut seq = vec![0x1b, b'['];
+        if let Some(i1) = i1 {
+            seq.push(i1);
+        }
+        for (idx, param) in params.iter().enumerate() {
+            if idx > 0 {
+                seq.push(b';');
+            }
+            for (sub_idx, value) in param.iter().enumerate() {
+                if sub_idx > 0 {
+                    seq.push(b':');
+                }
+                seq.extend_from_slice(value.to_string().as_bytes());
+            }
+        }
+        if let Some(i2) = i2 {
+            seq.push(i2);
+        }
+        seq.push(c as u8);
+        seq
+    }
+
+    fn format_unhandled_osc(params: &[&[u8]]) -> Vec<u8> {
+        let mut seq = vec![0x1b, b']'];
+        for (idx, param) in params.iter().enumerate() {
+            if idx > 0 {
+                seq.push(b';');
+            }
+            seq.extend_from_slice(param);
+        }
+        seq.extend_from_slice(b"\x1b\\");
+        seq
+    }
+}
+
+fn build_snapshot(screen: &vt100::Screen, callbacks: &SessionCallbacks) -> Vec<u8> {
+    let mut snapshot = screen.state_formatted();
+    let mut prefix = Vec::new();
+
+    if let Some(title) = callbacks.window_title.as_ref() {
+        prefix.extend_from_slice(b"\x1b]2;");
+        prefix.extend_from_slice(title.as_bytes());
+        prefix.extend_from_slice(b"\x1b\\");
+    }
+    if screen.alternate_screen() {
+        prefix.extend_from_slice(b"\x1b[?1049h");
+    }
+    prefix.extend_from_slice(&callbacks.passthrough_sequences_formatted());
+
+    if prefix.is_empty() {
+        snapshot
+    } else {
+        prefix.append(&mut snapshot);
+        prefix
     }
 }
 
@@ -44,8 +142,18 @@ impl vt100::Callbacks for SessionCallbacks {
         match i1 {
             None => self.pending_da1_queries += 1,
             Some(b'>') => self.pending_da2_queries += 1,
-            _ => {}
+            _ => {
+                self.push_passthrough_sequence(Self::format_unhandled_csi(i1, i2, params, c));
+            }
         }
+    }
+
+    fn unhandled_escape(&mut self, _: &mut vt100::Screen, i1: Option<u8>, i2: Option<u8>, b: u8) {
+        self.push_passthrough_sequence(Self::format_unhandled_escape(i1, i2, b));
+    }
+
+    fn unhandled_osc(&mut self, _: &mut vt100::Screen, params: &[&[u8]]) {
+        self.push_passthrough_sequence(Self::format_unhandled_osc(params));
     }
 }
 
@@ -122,24 +230,7 @@ impl Session {
 
     /// Generate escape sequences that reproduce the current terminal state.
     pub fn snapshot(&self) -> Vec<u8> {
-        let mut snapshot = self.parser.screen().state_formatted();
-        let mut prefix = Vec::new();
-
-        if let Some(title) = self.parser.callbacks().window_title.as_ref() {
-            prefix.extend_from_slice(b"\x1b]2;");
-            prefix.extend_from_slice(title.as_bytes());
-            prefix.extend_from_slice(b"\x1b\\");
-        }
-        if self.parser.screen().alternate_screen() {
-            prefix.extend_from_slice(b"\x1b[?1049h");
-        }
-
-        if prefix.is_empty() {
-            snapshot
-        } else {
-            prefix.append(&mut snapshot);
-            prefix
-        }
+        build_snapshot(self.parser.screen(), self.parser.callbacks())
     }
 
     pub fn take_pending_da_queries(&mut self) -> (usize, usize) {
@@ -171,5 +262,32 @@ impl Session {
             }
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_snapshot, SessionCallbacks};
+
+    #[test]
+    fn snapshot_preserves_unhandled_osc_sequences() {
+        let mut parser =
+            vt100::Parser::new_with_callbacks(24, 80, 1000, SessionCallbacks::default());
+        parser.process(b"\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\");
+
+        let snapshot = build_snapshot(parser.screen(), parser.callbacks());
+        let snapshot = String::from_utf8_lossy(&snapshot);
+
+        assert!(snapshot.contains("\x1b]8;;https://example.com\x1b\\"));
+        assert!(snapshot.contains("\x1b]8;;\x1b\\"));
+    }
+
+    #[test]
+    fn handled_sgr_is_not_added_to_passthrough_sequences() {
+        let mut parser =
+            vt100::Parser::new_with_callbacks(24, 80, 1000, SessionCallbacks::default());
+        parser.process(b"\x1b[31mRED\x1b[m");
+
+        assert!(parser.callbacks().passthrough_sequences.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- `git diff` などのコマンドを attach/reconnect 後に表示する際、OSC 8 ハイパーリンクなど `vt100` が未対応のエスケープシーケンスが `state_formatted()` によって欠落する問題を修正
- `SessionCallbacks` に `unhandled_osc` / `unhandled_escape` / `unhandled_csi` を実装し、未処理シーケンスを蓄積して `build_snapshot()` の prefix として再送するようにした
- passthrough バッファは 256 シーケンス / 16 KiB に上限を設定し、無制限な増加を防止

## Root Cause

`snapshot()` が内部で呼ぶ `vt100::Screen::state_formatted()` は、vt100 クレートが処理できるシーケンス（SGR 色コードなど）しか再生成しない。OSC 8 などの未対応シーケンスは `unhandled_osc` コールバックに流れるだけで破棄されていた。

- **live OUTPUT（リアルタイム）**: raw バイト列をそのまま転送するため問題なし
- **snapshot（attach 時初期表示）**: `state_formatted()` 経由で再構成するため未対応シーケンスが欠落

## Test plan

- [x] `snapshot_preserves_unhandled_osc_sequences` — OSC 8 が snapshot に保持されることを確認
- [x] `handled_sgr_is_not_added_to_passthrough_sequences` — SGR（vt100 が処理済み）が passthrough に重複しないことを確認
- [x] `cargo test` 全テスト通過
- [x] `cargo check` エラーなし

## Limitations

OSC 8 のような「テキスト範囲に紐づく状態」は vt100 がセル属性として保持しないため、カーソル位置との完全な整合は保証されない。将来的な完全対応には raw PTY 出力のリングバッファ再送設計が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)