### PR TITLE
Remove setup-time binary and terminal size options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Processes survive Neovim restarts. Terminal rendering is delegated to Neovim's n
 ```sh
 # Create a new persistent session (forks into background)
 pterm new mysession
-pterm new mysession --cols 120 --rows 40
 pterm new mysession -- /bin/zsh        # custom command
 
 # Attach bridge mode (for terminal clients)
@@ -86,20 +85,10 @@ require("pterm").setup()
 
 -- Default configuration:
 require("pterm").setup({
-  -- Path to pterm binary (auto-detected if nil)
-  binary = nil,
   -- Default shell command
   shell = vim.env.SHELL or "/bin/sh",
-  -- Default terminal size for `pterm new` when created outside Neovim
-  -- (the bridge reads the actual PTY size via TIOCGWINSZ at attach time)
-  cols = 80,
-  rows = 24,
   -- Socket directory (nil = let daemon decide)
   socket_dir = nil,
-  -- Max wait time for daemon socket creation after `pterm new`
-  attach_wait_ms = 3000,
-  -- Poll interval while waiting for socket
-  attach_poll_ms = 50,
 })
 ```
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -51,7 +51,7 @@ Current approach:
 
 Responsibilities:
 
-- binary discovery (`setup.binary` override supported)
+- binary discovery from the plugin worktree, Nix build output, or `PATH`
 - session create/list/kill orchestration
 - attach lifecycle in Neovim
 

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -2,13 +2,8 @@ local M = {}
 
 --- Configuration
 M.config = {
-	-- Path to pterm binary (auto-detected if nil)
-	binary = nil,
 	-- Default shell command
 	shell = vim.env.SHELL or "/bin/sh",
-	-- Default terminal size
-	cols = 80,
-	rows = 24,
 	-- Socket directory (nil = let daemon decide)
 	socket_dir = nil,
 }
@@ -18,10 +13,6 @@ M.connections = {}
 
 --- Find the pterm binary.
 local function find_binary()
-	if M.config.binary then
-		return M.config.binary
-	end
-
 	-- Look relative to plugin root directory (lua/pterm/init.lua -> repo root)
 	local script_path = debug.getinfo(1, "S").source:sub(2)
 	local repo_root = vim.fn.fnamemodify(script_path, ":h:h:h")
@@ -43,7 +34,7 @@ local function find_binary()
 		return "pterm"
 	end
 
-	error("pterm binary not found. Build with: cargo build --release")
+	error("pterm binary not found. Install pterm with Nix or build it in this repository.")
 end
 
 --- Get socket directory (must match daemon's socket_dir() logic).

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,10 +41,10 @@ fn print_usage() {
         "pterm - persistent terminal daemon
 
 Usage:
-  pterm new    <session-name> [--cols N] [--rows N] [--] <command> [args...]
-  pterm attach <session-name> [--cols N] [--rows N]
+  pterm new    <session-name> [--] <command> [args...]
+  pterm attach <session-name>
                # attach to session (bridge mode)
-  pterm open   <session-name> [--cols N] [--rows N] [--] <command> [args...]
+  pterm open   <session-name> [--] <command> [args...]
                # attach if exists, otherwise create and attach
   pterm list   [prefix]
   pterm kill   <session-name>
@@ -64,8 +64,6 @@ Environment:
 
 fn cmd_new(args: &[String], quiet: bool) -> io::Result<()> {
     let mut session_name = String::new();
-    let mut cols: u16 = 80;
-    let mut rows: u16 = 24;
     let mut cmd_args: Vec<String> = Vec::new();
     let mut parsing_opts = true;
 
@@ -76,13 +74,7 @@ fn cmd_new(args: &[String], quiet: bool) -> io::Result<()> {
             i += 1;
             continue;
         }
-        if parsing_opts && args[i] == "--cols" {
-            i += 1;
-            cols = args.get(i).and_then(|s| s.parse().ok()).unwrap_or(80);
-        } else if parsing_opts && args[i] == "--rows" {
-            i += 1;
-            rows = args.get(i).and_then(|s| s.parse().ok()).unwrap_or(24);
-        } else if session_name.is_empty() {
+        if session_name.is_empty() {
             session_name = args[i].clone();
         } else {
             cmd_args.push(args[i].clone());
@@ -172,7 +164,7 @@ fn cmd_new(args: &[String], quiet: bool) -> io::Result<()> {
     let cmd = &cmd_args[0];
     let str_args: Vec<&str> = cmd_args.iter().map(|s| s.as_str()).collect();
 
-    let session = Session::new(session_name, cmd, &str_args, cols, rows)?;
+    let session = Session::new(session_name, cmd, &str_args)?;
     let mut server = Server::new(&sess_dir, session)?;
     server.run()?;
 
@@ -281,7 +273,7 @@ fn cmd_kill(args: &[String]) -> io::Result<()> {
 }
 
 /// Extract session name from args following the same parsing rule as `cmd_new`:
-/// first non-option argument, where `--cols/--rows` consume their next value.
+/// first non-option argument, ignoring an optional `--` separator.
 fn parse_session_name(args: &[String]) -> Option<&str> {
     let mut parsing_opts = true;
     let mut i = 0;
@@ -289,10 +281,6 @@ fn parse_session_name(args: &[String]) -> Option<&str> {
         if parsing_opts && args[i] == "--" {
             parsing_opts = false;
             i += 1;
-            continue;
-        }
-        if parsing_opts && (args[i] == "--cols" || args[i] == "--rows") {
-            i += 2;
             continue;
         }
         return Some(args[i].as_str());
@@ -318,18 +306,10 @@ fn wait_for_socket(sock: &Path, timeout: Duration, poll: Duration) -> io::Result
 
 fn cmd_attach(args: &[String]) -> io::Result<()> {
     let mut session_name = String::new();
-    let mut cols: Option<u16> = None;
-    let mut rows: Option<u16> = None;
 
     let mut i = 0;
     while i < args.len() {
-        if args[i] == "--cols" {
-            i += 1;
-            cols = args.get(i).and_then(|s| s.parse().ok());
-        } else if args[i] == "--rows" {
-            i += 1;
-            rows = args.get(i).and_then(|s| s.parse().ok());
-        } else if session_name.is_empty() {
+        if session_name.is_empty() {
             session_name = args[i].clone();
         }
         i += 1;
@@ -346,7 +326,7 @@ fn cmd_attach(args: &[String]) -> io::Result<()> {
         std::process::exit(1);
     }
 
-    let exit_code = bridge::run(&sock, cols, rows)?;
+    let exit_code = bridge::run(&sock, None, None)?;
     std::process::exit(exit_code);
 }
 
@@ -355,23 +335,6 @@ fn cmd_open(args: &[String]) -> io::Result<()> {
         eprintln!("Error: session name required");
         std::process::exit(1);
     });
-
-    // Extract --cols/--rows for bridge
-    let mut cols: Option<u16> = None;
-    let mut rows: Option<u16> = None;
-    {
-        let mut i = 0;
-        while i < args.len() {
-            if args[i] == "--cols" {
-                i += 1;
-                cols = args.get(i).and_then(|s| s.parse().ok());
-            } else if args[i] == "--rows" {
-                i += 1;
-                rows = args.get(i).and_then(|s| s.parse().ok());
-            }
-            i += 1;
-        }
-    }
 
     let sock = session_socket_path(name);
     if !sock.exists() {
@@ -390,7 +353,7 @@ fn cmd_open(args: &[String]) -> io::Result<()> {
         }
     }
 
-    let exit_code = bridge::run(&sock, cols, rows)?;
+    let exit_code = bridge::run(&sock, None, None)?;
     std::process::exit(exit_code);
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -282,7 +282,9 @@ pub struct Session {
 
 impl Session {
     /// Create a new session with the given name and command.
-    pub fn new(name: String, cmd: &str, args: &[&str], cols: u16, rows: u16) -> io::Result<Self> {
+    pub fn new(name: String, cmd: &str, args: &[&str]) -> io::Result<Self> {
+        let cols = 80;
+        let rows = 24;
         let pty = Pty::spawn(cmd, args, cols, rows)?;
         Ok(Self {
             name,


### PR DESCRIPTION
## Summary
- remove setup-time binary override and default cols/rows from the Lua plugin config
- drop CLI support for --cols/--rows on new, attach, and open
- update docs and examples to match the nix-based installation flow

## Verification
- cargo test
- cargo fmt --check
- stylua --check lua/pterm/init.lua