### PR TITLE
Require a session name for :Pterm

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ pterm kill parent          # kills parent and parent/child
 ## Neovim Usage
 
 ```vim
-:Pterm              " opens/creates 'main' session
 :Pterm dev          " opens/creates named session
 :Pterm dev zsh      " opens/creates session with custom command
 :PtermList          " list sessions

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -256,9 +256,9 @@ end
 function M.open(session_name, args)
 	args = args or {}
 
-	-- Default session name
 	if not session_name or session_name == "" then
-		session_name = "main"
+		vim.notify("Session name required", vim.log.levels.ERROR)
+		return
 	end
 
 	-- Already connected?


### PR DESCRIPTION
## Summary
- stop defaulting  to a  session when no name is provided
- show the same session-name-required error behavior as the CLI instead
- update the README Neovim usage example to remove the implicit  session

Fixes #2

## Verification
- cargo test
- stylua --check lua/pterm/init.lua
- nvim --headless -u NONE -i NONE -c "set shadafile=/tmp/pterm-test.shada" -c "set rtp+=/Users/tak/ghq/github.com/ttak0422/pterm" -c "lua vim.notify=function(msg, level) print(msg) end; local p=require('pterm'); p.open(nil, {}); if next(p.connections) ~= nil then error('unexpected connection created') end" -c "qa!"