### PR TITLE
feat: sync Neovim env vars to persistent sessions on attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,72 @@ require("pterm").setup({
   shell = vim.env.SHELL or "/bin/sh",
   -- Socket directory (nil = let daemon decide)
   socket_dir = nil,
+  -- Function returning env vars to push into the session on every attach.
+  -- Keys are variable names; string values are exported, nil/false values
+  -- unset the variable.  Return nil or {} to disable env sync.
+  sync_env = function(_session_name)
+    return {
+      EDITOR               = vim.env.EDITOR,
+      VISUAL               = vim.env.VISUAL,
+      GIT_EDITOR           = vim.env.GIT_EDITOR,
+      NVIM_LISTEN_ADDRESS  = vim.v.servername ~= "" and vim.v.servername or nil,
+      NVIM                 = vim.v.progpath   ~= "" and vim.v.progpath   or nil,
+    }
+  end,
+})
+```
+
+## Env Sync
+
+When using **zsh**, pterm automatically keeps `EDITOR`, `VISUAL`, `GIT_EDITOR`,
+`NVIM_LISTEN_ADDRESS`, and `NVIM` in sync with the Neovim instance that is
+currently attached to a session.
+
+On every `:Pterm <session>` call the bridge pushes those values from the active
+Neovim into the session.  The next shell prompt sources them, so any command
+you run after that (e.g. `git commit`) picks up the right `EDITOR`.
+
+### How it works (zsh)
+
+pterm uses zsh's `ZDOTDIR` mechanism to install a `precmd` hook transparently.
+When creating a session pterm:
+
+1. generates a small `zdotdir/` shim inside the session directory,
+2. sets `ZDOTDIR` to that directory in the child process environment.
+
+The shim's `.zshenv` and `.zshrc` forward to your original dotfiles and then
+register a `precmd` hook that sources the per-session `env.sh` file before
+each prompt.  `ZDOTDIR` is unset immediately so child shells you open from
+within the terminal behave normally.
+
+> **Note:** pterm sets `ZDOTDIR` only for the shell it spawns.  Your existing
+> `ZDOTDIR` (if any) is left untouched for all other processes.
+
+### Other shells
+
+For shells other than zsh the hook must be added manually.  Add to your shell's
+rc file:
+
+```bash
+# bash
+if [[ -n "${PTERM_ENV_FILE:-}" ]]; then
+  PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }[[ -r \"$PTERM_ENV_FILE\" ]] && source \"$PTERM_ENV_FILE\""
+fi
+```
+
+### Customising synced variables
+
+Override `sync_env` in your `setup()` call to sync additional variables or
+disable the feature entirely:
+
+```lua
+require("pterm").setup({
+  sync_env = function(_session_name)
+    return {
+      EDITOR  = vim.env.EDITOR,
+      GOPATH  = vim.env.GOPATH,   -- extra variable
+    }
+  end,
 })
 ```
 

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -6,6 +6,21 @@ M.config = {
 	shell = vim.env.SHELL or "/bin/sh",
 	-- Socket directory (nil = let daemon decide)
 	socket_dir = nil,
+	-- Function returning a table of env vars to sync on each attach.
+	-- Keys are variable names; values are strings to export, or false/nil to
+	-- unset.  Return nil or an empty table to disable env sync.
+	--
+	-- Example: to also forward GOPATH:
+	--   sync_env = function(_) return { GOPATH = vim.env.GOPATH } end
+	sync_env = function(_session_name)
+		return {
+			EDITOR = vim.env.EDITOR,
+			VISUAL = vim.env.VISUAL,
+			GIT_EDITOR = vim.env.GIT_EDITOR,
+			NVIM_LISTEN_ADDRESS = vim.v.servername ~= "" and vim.v.servername or nil,
+			NVIM = vim.v.progpath ~= "" and vim.v.progpath or nil,
+		}
+	end,
 }
 
 --- Active connections: session_name -> { buf, job_id, session_name }
@@ -177,6 +192,28 @@ local function start_terminal(session_name, cmd)
 	vim.api.nvim_set_option_value("foldcolumn", "0", { win = win })
 	vim.api.nvim_set_option_value("statuscolumn", "", { win = win })
 
+	-- Build PTERM_SYNC_ENV from the sync_env config callback.
+	-- The bridge process will read this and send a SET_ENV frame to the daemon
+	-- before the initial RESIZE, so the session env file is updated on every
+	-- attach with the current Neovim's relevant env vars.
+	local pterm_sync_env = ""
+	if type(M.config.sync_env) == "function" then
+		local ok, result = pcall(M.config.sync_env, session_name)
+		if ok and type(result) == "table" then
+			local env_map = {}
+			for k, v in pairs(result) do
+				if type(k) == "string" and k ~= "" then
+					if v == false then
+						env_map[k] = vim.NIL
+					elseif type(v) == "string" and v ~= "" then
+						env_map[k] = v
+					end
+				end
+			end
+			pterm_sync_env = vim.json.encode(env_map)
+		end
+	end
+
 	-- Let the bridge read the actual PTY size via TIOCGWINSZ instead of
 	-- passing --cols/--rows from Lua.  jobstart({term=true}) creates a PTY
 	-- sized to the current window, and the bridge's get_winsize(stdout)
@@ -184,6 +221,7 @@ local function start_terminal(session_name, cmd)
 	local job_id
 	job_id = vim.fn.jobstart(cmd, {
 		term = true,
+		env = { PTERM_SYNC_ENV = pterm_sync_env },
 		on_exit = function(_, exit_code, _)
 			vim.schedule(function()
 				local conn = connections[session_name]

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -28,6 +28,11 @@ pub mod client {
 
     /// Request terminal redraw (no payload)
     pub const REDRAW: u8 = 0x04;
+
+    /// Sync environment variables to the session env file.
+    /// Payload: UTF-8 JSON object mapping variable names to string values or
+    /// null. A string value exports the variable; null unsets it.
+    pub const SET_ENV: u8 = 0x05;
 }
 
 /// Daemon → Client message types

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -190,6 +190,16 @@ pub fn run(
     poll.registry()
         .register(&mut wake_source, TOKEN_WAKE, Interest::READABLE)?;
 
+    // Send SET_ENV frame if PTERM_SYNC_ENV is set in the bridge process
+    // environment.  Neovim passes this via jobstart(..., {env = {...}}) so each
+    // attach carries the current Neovim's env vars.
+    if let Ok(sync_env) = std::env::var("PTERM_SYNC_ENV") {
+        if !sync_env.is_empty() {
+            let msg = proto::encode(proto::client::SET_ENV, sync_env.as_bytes());
+            socket.write_all(&msg)?;
+        }
+    }
+
     // Send initial RESIZE to sync terminal size.
     // CLI-supplied values take priority, then TIOCGWINSZ, then the default
     // terminal size.

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,73 @@ use std::os::unix::fs::FileTypeExt;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+/// Return true when `cmd` resolves to the zsh executable.
+fn is_zsh(cmd: &str) -> bool {
+    Path::new(cmd)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n == "zsh")
+        .unwrap_or(false)
+}
+
+/// Create a ZDOTDIR shim directory for the given session.
+///
+/// The shim intercepts `.zshenv` and `.zshrc` loading transparently:
+///
+/// - `.zshenv` forwards to the user's original `.zshenv`
+/// - `.zshrc` unsets ZDOTDIR (so child shells behave normally), forwards to
+///   the user's original `.zshrc`, then installs a `precmd` hook that sources
+///   `$PTERM_ENV_FILE` before each prompt.
+///
+/// Returns the path to the created zdotdir directory.
+fn setup_zsh_zdotdir(sess_dir: &Path) -> io::Result<std::path::PathBuf> {
+    let zdotdir = sess_dir.join("zdotdir");
+    std::fs::create_dir_all(&zdotdir)?;
+
+    // Resolve the user's original dotfile directory (ZDOTDIR or HOME).
+    let orig = std::env::var("ZDOTDIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| std::env::var("HOME").ok())
+        .unwrap_or_else(|| "~".to_string());
+
+    // Single-quote a path for safe shell embedding.
+    let q = |s: &str| format!("'{}'", s.replace('\'', "'\\''"));
+    let orig_q = q(&orig);
+
+    let zshenv = format!(
+        "# pterm: forward to original .zshenv\n\
+         [[ -f {orig}/.zshenv ]] && builtin source {orig}/.zshenv\n",
+        orig = orig_q,
+    );
+
+    let zshrc = format!(
+        "# pterm: restore ZDOTDIR for child shells and forward to original .zshrc\n\
+         unset ZDOTDIR\n\
+         [[ -f {orig}/.zshrc ]] && builtin source {orig}/.zshrc\n\
+         # Install pterm env-sync hook (no-op when PTERM_ENV_FILE is unset)\n\
+         if [[ -n ${{PTERM_ENV_FILE:-}} ]]; then\n\
+           autoload -Uz add-zsh-hook 2>/dev/null\n\
+           _pterm_precmd() {{ [[ -r $PTERM_ENV_FILE ]] && builtin source $PTERM_ENV_FILE; }}\n\
+           add-zsh-hook precmd _pterm_precmd\n\
+         fi\n",
+        orig = orig_q,
+    );
+
+    std::fs::write(zdotdir.join(".zshenv"), zshenv.as_bytes())?;
+    std::fs::write(zdotdir.join(".zshrc"), zshrc.as_bytes())?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        for name in &[".zshenv", ".zshrc"] {
+            std::fs::set_permissions(zdotdir.join(name), std::fs::Permissions::from_mode(0o600))?;
+        }
+    }
+
+    Ok(zdotdir)
+}
+
 fn print_usage() {
     eprintln!(
         "pterm - persistent terminal daemon
@@ -141,11 +208,29 @@ fn cmd_new(args: &[String], quiet: bool) -> io::Result<()> {
     let cmd = &cmd_args[0];
     let str_args: Vec<&str> = cmd_args.iter().map(|s| s.as_str()).collect();
 
-    // Inject PTERM_ENV_FILE so the shell can source per-session env overrides
-    // pushed by Neovim at attach time.
+    // Always inject PTERM_ENV_FILE so the shell knows where Neovim's env
+    // overrides are written on each attach.
     let env_file = sess_dir.join("env.sh");
     let env_file_str = env_file.to_string_lossy().into_owned();
-    let extra_env = [("PTERM_ENV_FILE", env_file_str.as_str())];
+
+    // For zsh: create a ZDOTDIR shim that installs the precmd hook
+    // automatically.  Users do not need to modify their .zshrc.
+    let zdotdir_str: Option<String> = if is_zsh(cmd) {
+        match setup_zsh_zdotdir(&sess_dir) {
+            Ok(p) => Some(p.to_string_lossy().into_owned()),
+            Err(e) => {
+                log::warn!("Failed to set up zsh ZDOTDIR shim: {}", e);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let mut extra_env: Vec<(&str, &str)> = vec![("PTERM_ENV_FILE", &env_file_str)];
+    if let Some(ref zd) = zdotdir_str {
+        extra_env.push(("ZDOTDIR", zd.as_str()));
+    }
 
     let session = Session::new(session_name, cmd, &str_args, &extra_env)?;
     let mut server = Server::new(&sess_dir, session)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,13 @@ fn cmd_new(args: &[String], quiet: bool) -> io::Result<()> {
     let cmd = &cmd_args[0];
     let str_args: Vec<&str> = cmd_args.iter().map(|s| s.as_str()).collect();
 
-    let session = Session::new(session_name, cmd, &str_args)?;
+    // Inject PTERM_ENV_FILE so the shell can source per-session env overrides
+    // pushed by Neovim at attach time.
+    let env_file = sess_dir.join("env.sh");
+    let env_file_str = env_file.to_string_lossy().into_owned();
+    let extra_env = [("PTERM_ENV_FILE", env_file_str.as_str())];
+
+    let session = Session::new(session_name, cmd, &str_args, &extra_env)?;
     let mut server = Server::new(&sess_dir, session)?;
     server.run()?;
 

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -1,6 +1,6 @@
 use nix::libc;
 use nix::pty::{openpty, OpenptyResult};
-use nix::unistd::{dup2, execvp, fork, setsid, ForkResult, Pid};
+use nix::unistd::{dup2, execve, execvp, fork, setsid, ForkResult, Pid};
 use std::ffi::CString;
 use std::io;
 use std::os::fd::{AsRawFd, OwnedFd, RawFd};
@@ -15,7 +15,16 @@ impl Pty {
     /// `cmd` is the command to execute (e.g., "/bin/bash").
     /// `args` are the arguments (argv[0] should be the command name).
     /// `cols` and `rows` set the initial terminal size.
-    pub fn spawn(cmd: &str, args: &[&str], cols: u16, rows: u16) -> io::Result<Self> {
+    /// `extra_env` is a list of `(key, value)` pairs to add or override in the
+    /// child environment. When non-empty the child is started with `execve`
+    /// using the current process environment merged with the overrides.
+    pub fn spawn(
+        cmd: &str,
+        args: &[&str],
+        cols: u16,
+        rows: u16,
+        extra_env: &[(&str, &str)],
+    ) -> io::Result<Self> {
         // Open a pty pair
         let OpenptyResult { master, slave } = openpty(None, None).map_err(io::Error::other)?;
 
@@ -62,7 +71,22 @@ impl Pty {
                 // Exec the command
                 let c_cmd = CString::new(cmd).unwrap();
                 let c_args: Vec<CString> = args.iter().map(|a| CString::new(*a).unwrap()).collect();
-                execvp(&c_cmd, &c_args).ok();
+
+                if extra_env.is_empty() {
+                    execvp(&c_cmd, &c_args).ok();
+                } else {
+                    // Build full environment: current env merged with overrides.
+                    let mut env_map: std::collections::HashMap<String, String> =
+                        std::env::vars().collect();
+                    for (k, v) in extra_env {
+                        env_map.insert(k.to_string(), v.to_string());
+                    }
+                    let c_env: Vec<CString> = env_map
+                        .into_iter()
+                        .filter_map(|(k, v)| CString::new(format!("{}={}", k, v)).ok())
+                        .collect();
+                    execve(&c_cmd, &c_args, &c_env).ok();
+                }
 
                 // If exec fails
                 std::process::exit(127);

--- a/src/server.rs
+++ b/src/server.rs
@@ -35,6 +35,11 @@ pub struct Server {
     pending_pty_output: Vec<u8>,
     /// `true` after the EXIT message has been broadcast to clients.
     exit_sent: bool,
+    /// Per-client env payloads received via SET_ENV.
+    client_envs: HashMap<usize, Vec<u8>>,
+    /// ID of the client whose env vars are currently written to env_file_path.
+    /// Switches to a different client when that client sends the first INPUT.
+    active_env_client: Option<usize>,
 }
 
 impl Server {
@@ -77,6 +82,8 @@ impl Server {
             next_client_id: 0,
             pending_pty_output: Vec::new(),
             exit_sent: false,
+            client_envs: HashMap::new(),
+            active_env_client: None,
         })
     }
 
@@ -121,13 +128,13 @@ impl Server {
                         if event.is_readable() {
                             if let Err(e) = self.handle_client_data(id, &mut client_buf) {
                                 log::warn!("Client {} read error: {}", id, e);
-                                self.clients.remove(&id);
+                                self.remove_client(id);
                             }
                         }
                         if event.is_writable() {
                             if let Err(e) = self.flush_client_send_buf(id) {
                                 log::warn!("Client {} write error: {}", id, e);
-                                self.clients.remove(&id);
+                                self.remove_client(id);
                             }
                         }
                     }
@@ -310,7 +317,7 @@ impl Server {
         }
         for id in disconnected {
             log::info!("Client {} disconnected", id);
-            self.clients.remove(&id);
+            self.remove_client(id);
         }
     }
 
@@ -370,7 +377,7 @@ impl Server {
         }
         for id in disconnected {
             log::info!("Client {} disconnected during flush", id);
-            self.clients.remove(&id);
+            self.remove_client(id);
         }
     }
 
@@ -393,7 +400,7 @@ impl Server {
 
         if remove {
             log::info!("Client {} disconnected", client_id);
-            self.clients.remove(&client_id);
+            self.remove_client(client_id);
         } else if let Some(client) = self.clients.get_mut(&client_id) {
             if !client.recv_buf.is_empty() {
                 // Flush pending PTY output so the vt state is current before
@@ -420,6 +427,28 @@ impl Server {
             match frame.msg_type {
                 proto::client::INPUT => {
                     self.session.write_pty(&frame.payload)?;
+                    // Switch active env client when input arrives from a
+                    // different client than the current one.  This ensures
+                    // env.sh always reflects the Neovim that the user is
+                    // actively typing in, even when multiple clients are
+                    // simultaneously attached to the same session.
+                    if self.active_env_client != Some(client_id) {
+                        if let Some(env_payload) = self.client_envs.get(&client_id).cloned() {
+                            match self.write_env_file(&env_payload) {
+                                Ok(()) => {
+                                    log::info!(
+                                        "Active env client: {:?} → {}",
+                                        self.active_env_client,
+                                        client_id
+                                    );
+                                    self.active_env_client = Some(client_id);
+                                }
+                                Err(e) => {
+                                    log::warn!("Client {} env switch failed: {}", client_id, e)
+                                }
+                            }
+                        }
+                    }
                 }
                 proto::client::RESIZE => {
                     let (cols, rows) = match proto::parse_resize(&frame.payload) {
@@ -444,8 +473,18 @@ impl Server {
                 }
                 proto::client::DETACH => {}
                 proto::client::SET_ENV => {
-                    if let Err(e) = self.write_env_file(&frame.payload) {
-                        log::warn!("Client {} SET_ENV error: {}", client_id, e);
+                    self.client_envs.insert(client_id, frame.payload.clone());
+                    // Write env.sh immediately only when this client is already
+                    // the active one, or when no active client exists yet (first
+                    // attach, or after the previous active client disconnected).
+                    if self.active_env_client.is_none() || self.active_env_client == Some(client_id)
+                    {
+                        match self.write_env_file(&frame.payload) {
+                            Ok(()) => self.active_env_client = Some(client_id),
+                            Err(e) => {
+                                log::warn!("Client {} SET_ENV error: {}", client_id, e)
+                            }
+                        }
                     }
                 }
                 proto::client::REDRAW => {
@@ -465,6 +504,34 @@ impl Server {
             client.recv_buf = recv_buf;
         }
         Ok(flush_all)
+    }
+
+    /// Remove a client from all tracking structures.
+    ///
+    /// When the active env client disconnects, fall back to another connected
+    /// client (if any) so env.sh stays up to date.
+    fn remove_client(&mut self, client_id: usize) {
+        self.clients.remove(&client_id);
+        self.client_envs.remove(&client_id);
+
+        if self.active_env_client == Some(client_id) {
+            self.active_env_client = None;
+            // Fall back to an arbitrary remaining client.
+            if let Some((&other_id, payload)) = self.client_envs.iter().next() {
+                let payload = payload.clone();
+                match self.write_env_file(&payload) {
+                    Ok(()) => {
+                        log::info!(
+                            "Active env client fell back to {} after {} disconnected",
+                            other_id,
+                            client_id
+                        );
+                        self.active_env_client = Some(other_id);
+                    }
+                    Err(e) => log::warn!("Env fallback write error: {}", e),
+                }
+            }
+        }
     }
 
     /// Write per-session env file from a SET_ENV JSON payload.

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,6 +24,8 @@ struct Client {
 
 pub struct Server {
     socket_path: PathBuf,
+    /// Path to the per-session env file updated by SET_ENV frames.
+    env_file_path: PathBuf,
     session: Session,
     poll: Poll,
     listener: UnixListener,
@@ -67,6 +69,7 @@ impl Server {
 
         Ok(Self {
             socket_path,
+            env_file_path: session_dir.join("env.sh"),
             session,
             poll,
             listener,
@@ -440,6 +443,11 @@ impl Server {
                     }
                 }
                 proto::client::DETACH => {}
+                proto::client::SET_ENV => {
+                    if let Err(e) = self.write_env_file(&frame.payload) {
+                        log::warn!("Client {} SET_ENV error: {}", client_id, e);
+                    }
+                }
                 proto::client::REDRAW => {
                     log::info!("Redraw requested by client {}", client_id);
                     let mut redraw_data = b"\x1b[2J\x1b[H".to_vec();
@@ -457,6 +465,57 @@ impl Server {
             client.recv_buf = recv_buf;
         }
         Ok(flush_all)
+    }
+
+    /// Write per-session env file from a SET_ENV JSON payload.
+    ///
+    /// The payload is a UTF-8 JSON object: `{"KEY": "value", "OTHER": null}`.
+    /// String values produce `export KEY='value'`; null produces `unset KEY`.
+    /// The file is written atomically (write temp → rename) with mode 0600.
+    fn write_env_file(&self, payload: &[u8]) -> io::Result<()> {
+        let map: std::collections::HashMap<String, serde_json::Value> =
+            serde_json::from_slice(payload).map_err(io::Error::other)?;
+
+        let mut lines: Vec<String> = Vec::with_capacity(map.len());
+        for (k, v) in &map {
+            // Reject keys that would break shell syntax.
+            if k.is_empty() || k.contains('=') || k.contains('\0') || k.contains('\n') {
+                log::warn!("SET_ENV: skipping invalid key {:?}", k);
+                continue;
+            }
+            match v {
+                serde_json::Value::String(s) => {
+                    // Escape single quotes so the value is safe in single-quoted shell strings.
+                    let escaped = s.replace('\'', "'\\''");
+                    lines.push(format!("export {}='{}'", k, escaped));
+                }
+                serde_json::Value::Null => {
+                    lines.push(format!("unset {}", k));
+                }
+                _ => {}
+            }
+        }
+        lines.sort();
+
+        let content = lines.join("\n") + "\n";
+        let tmp_path = self.env_file_path.with_file_name("env.sh.tmp");
+
+        std::fs::write(&tmp_path, content.as_bytes())?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))?;
+        }
+
+        std::fs::rename(&tmp_path, &self.env_file_path)?;
+
+        log::info!(
+            "Env file updated ({} entries) at {:?}",
+            map.len(),
+            self.env_file_path
+        );
+        Ok(())
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -302,10 +302,17 @@ pub struct Session {
 
 impl Session {
     /// Create a new session with the given name and command.
-    pub fn new(name: String, cmd: &str, args: &[&str]) -> io::Result<Self> {
+    /// `extra_env` is forwarded to `Pty::spawn` as additional environment
+    /// variables for the child process (see `Pty::spawn` for details).
+    pub fn new(
+        name: String,
+        cmd: &str,
+        args: &[&str],
+        extra_env: &[(&str, &str)],
+    ) -> io::Result<Self> {
         let cols = DEFAULT_TERMINAL_COLS;
         let rows = DEFAULT_TERMINAL_ROWS;
-        let pty = Pty::spawn(cmd, args, cols, rows)?;
+        let pty = Pty::spawn(cmd, args, cols, rows, extra_env)?;
         Ok(Self {
             name,
             pty,


### PR DESCRIPTION
## Summary

持続セッションにアタッチするたびに、Neovim が `EDITOR`・`VISUAL`・`NVIM_LISTEN_ADDRESS` などの環境変数をシェルへ注入できるようにします。

**zsh ユーザーはシェル設定の変更不要です。**

## 仕組み

### アタッチ時の注入フロー

```
:Pterm <session>  (Neovim)
  └─ jobstart で bridge を起動（PTERM_SYNC_ENV={"EDITOR":"nvim",...} を env に渡す）
     └─ bridge: SET_ENV(0x05) フレームを daemon に送信
        └─ daemon: env.sh を原子的に更新 (mode 0600)
           └─ 次のプロンプト表示時に precmd フックが env.sh を source
```

### zsh の自動フック（ZDOTDIR）

セッション作成時に `<session_dir>/zdotdir/` を生成し `ZDOTDIR` に設定：

- `zdotdir/.zshenv` → ユーザーの `~/.zshenv` へ転送
- `zdotdir/.zshrc` → `ZDOTDIR` を即 unset → ユーザーの `~/.zshrc` を source → `precmd` フックを追加

子シェルは通常通り `~/.zshrc` を読む（ZDOTDIR は unset 済みのため）。

### 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `proto/src/lib.rs` | `SET_ENV = 0x05` を追加 |
| `src/pty.rs` | `Pty::spawn` に `extra_env` 引数（`execve` で注入） |
| `src/session.rs` | `Session::new` に `extra_env` 引数を追加 |
| `src/main.rs` | `PTERM_ENV_FILE` 注入 + zsh 向け `setup_zsh_zdotdir()` |
| `src/server.rs` | `SET_ENV` ハンドラ + `write_env_file()` |
| `src/bridge.rs` | アタッチ時に `PTERM_SYNC_ENV` → SET_ENV 送信 |
| `lua/pterm/init.lua` | `sync_env` 設定 + `PTERM_SYNC_ENV` の jobstart 注入 |
| `README.md` | Env Sync セクション追加（ZDOTDIR の説明、bash フォールバック） |

## Test plan

- [ ] `pterm new <session>` 後に `echo $PTERM_ENV_FILE` がパスを返すこと
- [ ] zsh セッションで `echo $ZDOTDIR` が空（unset 済み）であること
- [ ] `:Pterm <session>` 後に `env.sh` が生成されること
- [ ] 次のプロンプトで `echo $EDITOR` が Neovim のパスを返すこと
- [ ] Neovim 再起動・再アタッチで `NVIM_LISTEN_ADDRESS` が更新されること
- [ ] ユーザーの `.zshrc`（aliases、プラグイン等）が通常通り読み込まれること
- [ ] `sync_env = function() return {} end` で無効化できること
- [ ] 全テスト通過 (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)