### PR TITLE
feat: auto-redraw on BufEnter/TermEnter to fix rendering corruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ require("pterm").setup({
   shell = vim.env.SHELL or "/bin/sh",
   -- Socket directory (nil = let daemon decide)
   socket_dir = nil,
+  -- Automatically redraw on BufEnter / TermEnter to recover from rendering
+  -- corruption that can occur during mode or window focus switches.
+  auto_redraw = true,
+  -- Debounce delay in milliseconds for automatic redraws.
+  auto_redraw_delay_ms = 1000,
 })
 ```
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,5 +1,13 @@
 # Configuration
 
+## Lua options
+
+| Option | Default | Description |
+|---|---|---|
+| `auto_redraw` | `true` | Automatically redraw on `BufEnter` / `TermEnter` to recover from rendering corruption during mode or window focus switches |
+| `auto_redraw_delay_ms` | `1000` | Debounce delay (ms) for automatic redraws |
+| `socket_dir` | `nil` | Override socket directory (nil = let daemon decide) |
+
 ## Environment variables
 
 | Variable | Description |

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -6,10 +6,13 @@ M.config = {
 	shell = vim.env.SHELL or "/bin/sh",
 	-- Socket directory (nil = let daemon decide)
 	socket_dir = nil,
+	auto_redraw = true,
+	auto_redraw_delay_ms = 50,
 }
 
 --- Active connections: session_name -> { buf, job_id, session_name }
 local connections = {}
+local redraw_timers = {}
 
 --- Find the pterm binary.
 local function find_binary()
@@ -129,6 +132,13 @@ local function teardown_connection(session_name, opts)
 		return
 	end
 
+	local timer = redraw_timers[session_name]
+	if timer then
+		timer:stop()
+		timer:close()
+		redraw_timers[session_name] = nil
+	end
+
 	connections[session_name] = nil
 
 	if opts.stop_job ~= false and conn.job_id then
@@ -151,6 +161,35 @@ local function teardown_connection(session_name, opts)
 	if opts.exit_code ~= nil then
 		vim.notify("Session '" .. session_name .. "' exited (" .. opts.exit_code .. ")", vim.log.levels.INFO)
 	end
+end
+
+local function schedule_redraw(session_name, delay_ms)
+	if not M.config.auto_redraw then
+		return
+	end
+	delay_ms = delay_ms or M.config.auto_redraw_delay_ms
+	local existing = redraw_timers[session_name]
+	if existing then
+		existing:stop()
+		existing:close()
+		redraw_timers[session_name] = nil
+	end
+	local timer = vim.uv.new_timer()
+	redraw_timers[session_name] = timer
+	timer:start(
+		delay_ms,
+		0,
+		vim.schedule_wrap(function()
+			timer:stop()
+			timer:close()
+			redraw_timers[session_name] = nil
+			local conn = connections[session_name]
+			if conn and conn.job_id then
+				local bin = find_binary()
+				vim.fn.jobstart({ bin, "redraw", session_name })
+			end
+		end)
+	)
 end
 
 --- Internal: create a terminal buffer and start a pterm bridge process.
@@ -276,6 +315,22 @@ local function start_terminal(session_name, cmd)
 			end,
 		})
 	end
+
+	vim.api.nvim_create_autocmd("BufEnter", {
+		group = augroup,
+		buffer = buf,
+		callback = function()
+			schedule_redraw(session_name)
+		end,
+	})
+
+	vim.api.nvim_create_autocmd("TermEnter", {
+		group = augroup,
+		buffer = buf,
+		callback = function()
+			schedule_redraw(session_name)
+		end,
+	})
 
 	vim.cmd("startinsert")
 end

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -13,9 +13,14 @@ M.config = {
 --- Active connections: session_name -> { buf, job_id, session_name }
 local connections = {}
 local redraw_timers = {}
+local cached_binary = nil
 
---- Find the pterm binary.
+--- Find the pterm binary (result is cached after the first successful lookup).
 local function find_binary()
+	if cached_binary then
+		return cached_binary
+	end
+
 	-- Look relative to plugin root directory (lua/pterm/init.lua -> repo root)
 	local script_path = debug.getinfo(1, "S").source:sub(2)
 	local repo_root = vim.fn.fnamemodify(script_path, ":h:h:h")
@@ -23,18 +28,21 @@ local function find_binary()
 	-- Prefer release build in development worktrees.
 	local release_bin = repo_root .. "/target/release/pterm"
 	if vim.fn.executable(release_bin) == 1 then
-		return release_bin
+		cached_binary = release_bin
+		return cached_binary
 	end
 
 	-- Nix build output
 	local nix_bin = repo_root .. "/result/bin/pterm"
 	if vim.fn.executable(nix_bin) == 1 then
-		return nix_bin
+		cached_binary = nix_bin
+		return cached_binary
 	end
 
 	-- Fall back to PATH
 	if vim.fn.executable("pterm") == 1 then
-		return "pterm"
+		cached_binary = "pterm"
+		return cached_binary
 	end
 
 	error("pterm binary not found. Install pterm with Nix or build it in this repository.")
@@ -180,9 +188,12 @@ local function schedule_redraw(session_name, delay_ms)
 		delay_ms,
 		0,
 		vim.schedule_wrap(function()
+			if redraw_timers[session_name] ~= timer then
+				return
+			end
+			redraw_timers[session_name] = nil
 			timer:stop()
 			timer:close()
-			redraw_timers[session_name] = nil
 			local conn = connections[session_name]
 			if conn and conn.job_id then
 				local bin = find_binary()

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -7,7 +7,7 @@ M.config = {
 	-- Socket directory (nil = let daemon decide)
 	socket_dir = nil,
 	auto_redraw = true,
-	auto_redraw_delay_ms = 50,
+	auto_redraw_delay_ms = 1000,
 }
 
 --- Active connections: session_name -> { buf, job_id, session_name }


### PR DESCRIPTION
## Summary

- `BufEnter` / `TermEnter` autocmd をpterm バッファにバッファローカルで登録し、ウィンドウフォーカス切替やターミナルモード再入場時に自動リドローを実行する
  - `BufEnter`: 他のウィンドウ/バッファからptermバッファにフォーカスが戻ったとき
  - `TermEnter`: ptermバッファ内でノーマルモード→ターミナルモードに切り替えたとき
- デバウンス（デフォルト1000ms）により連続発火時の不要なリドローを抑制
- コールバック内でタイマーの同一性チェックを行い、`vim.schedule_wrap`による遅延実行と`redraw_timers`更新の競合バグを修正
- `find_binary()`の結果をキャッシュし、イベント発火ごとのファイルシステム探索コストを削減
- `setup({ auto_redraw = false })` で無効化可能、`auto_redraw_delay_ms` でデバウンス遅延を調整可能

## Motivation

モード切替・ウィンドウフォーカス切替のタイミングで重い処理が中断されると描画が崩れることがある。これらのイベントを契機に自動リドローを仕掛けることで、ユーザーが手動で `:PtermRedraw` を実行しなくても描画が自動回復するようにする。

## Test plan

- [ ] ptermバッファを開き、他のウィンドウに切り替えて戻ったとき描画が正常であることを確認
- [ ] ノーマルモードからターミナルモードに入り直したとき描画が正常であることを確認
- [ ] `setup({ auto_redraw = false })` 設定時は自動リドローが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)