### PR TITLE
fix: replace stale-size snapshot on RESIZE to prevent rendering corruption

### DIFF
--- a/docs/adr/0001-rendering-corruption-mitigations.md
+++ b/docs/adr/0001-rendering-corruption-mitigations.md
@@ -86,41 +86,10 @@ Modes currently at risk:
 
 ---
 
-### 🟢 TODO-4 — Passthrough overflow in high-OSC workloads
-
-**Severity**: Low (normal Neovim editing), Medium (OSC-heavy apps)  
-**Status**: Logged but not structurally fixed
-
-**Problem**: The 256 seq / 16 KiB FIFO evicts oldest entries first. Normal Neovim editing is unlikely to overflow (cursor-shape changes, title updates, and focus events are sparse). However, terminal apps emitting frequent OSC 8 hyperlinks, OSC 52 clipboard writes, or desktop notifications (OSC 99) can realistically overflow.
-
-**Decision**: The logging added in PR #42 is sufficient for now. When TODO-3 promotes common modes to structured state, overflow risk shrinks naturally. Revisit limits after structured state work lands.
-
----
-
-### 🟢 TODO-5 — Reconnect regression test coverage
-
-**Severity**: Low  
-**Status**: Not yet added
-
-**Problem**: `vt100`'s `state_formatted()` correctness is assumed. If `vt100` mishandles a sequence internally (emits wrong output), neither the passthrough queue nor the logging catches it.
-
-**Decision**: Add integration-level reconnect tests for real Neovim workflows:
-- Alternate-screen enter/exit (Neovim startup/shutdown)
-- Cursor-shape transitions (normal ↔ insert mode)
-- Hyperlink open/close round-trip
-- Title push/pop stack
-- Resize-after-attach
-
-**Files to change**: `src/session.rs` (test module)
-
----
-
 ## Priority Order
 
 | # | TODO | Severity | Effort | Suggested PR |
 |---|------|----------|--------|--------------|
 | 1 | TODO-2: DA query reply | Medium | Small | Add to `fix/rendering-corruption` |
-| 2 | TODO-1: Multi-client resize | High | Medium | Separate PR after design confirmed |
+| 2 | TODO-1: Multi-client resize broadcast | High | Medium | Separate PR |
 | 3 | TODO-3: Structured state for top modes | Medium | Medium–Large | Separate PR per mode |
-| 4 | TODO-5: Reconnect regression tests | Low | Medium | Can accompany TODO-3 PRs |
-| 5 | TODO-4: Passthrough overflow | Low | Deferred | Revisit after TODO-3 |

--- a/docs/adr/0001-rendering-corruption-mitigations.md
+++ b/docs/adr/0001-rendering-corruption-mitigations.md
@@ -1,0 +1,134 @@
+# ADR-0001: Rendering Corruption Mitigations
+
+**Status**: In Progress  
+**Branch**: `fix/rendering-corruption`
+
+---
+
+## Context
+
+pterm uses a two-layer snapshot model:
+
+1. `vt100::Screen::state_formatted()` — reconstructs terminal state from what the `vt100` crate tracks internally
+2. `SessionCallbacks::passthrough_sequences` — bounded queue (256 seqs / 16 KiB) capturing sequences `vt100` does not handle
+
+On client attach/reconnect, `build_snapshot()` combines both layers and replays the byte stream into the Neovim terminal buffer. This design exposes several correctness risks when terminal state cannot be fully reconstructed from these two sources alone.
+
+---
+
+## Decisions and TODOs
+
+### ✅ DONE — RESIZE stale-buffer ordering (PR #43)
+
+**Problem**: After `RESIZE`, stale `OUTPUT` frames or an old-size snapshot could remain queued in the client's send buffer ahead of the new-size snapshot, causing the bridge to replay bytes sized for the wrong terminal dimensions.
+
+**Decision**: `send_snapshot_to_client` now clears the client's `send_buf` before enqueuing the fresh snapshot. `RESIZE` always issues a replacement snapshot regardless of `pending_snapshot` state.
+
+---
+
+### ✅ DONE — Corruption detection logging (PR #42 / refactor branch)
+
+**Problem**: Rendering corruption was silent and hard to correlate with server events.
+
+**Decision**: Added `warn!`/`debug!` log points for passthrough overflow, DA leakage, snapshot race window, send-buf backpressure, and unknown CSI/ESC sequences.
+
+---
+
+### 🔴 TODO-1 — Multi-client resize contention
+
+**Severity**: High  
+**Status**: Architecture decision required — not yet implemented
+
+**Problem**: The session has a single shared PTY. Any client's `RESIZE` changes the PTY dimensions for all clients. Only the resizing client receives a fresh replacement snapshot; other attached clients silently end up with a mismatched terminal size.
+
+**Options**:
+
+| Option | Trade-off |
+|--------|-----------|
+| A. Enforce single active display client per session | Simple; matches current real-world usage pattern |
+| B. Authoritative session size; additional clients are watch-only (read-only, no resize) | Allows monitoring from multiple terminals |
+| C. Per-client virtual canvas with server-side reflow | Highest fidelity; large implementation cost |
+
+**Recommended decision**: Option A — document and enforce single-display semantics. Reject or ignore `RESIZE` from a second client if one is already attached as a display client.
+
+**Files to change**: `src/server.rs` (RESIZE handler), `lua/pterm/init.lua` (attach guard), `docs/DESIGN.md`
+
+---
+
+### 🟡 TODO-2 — DA1/DA2 queries unanswered while client is attached
+
+**Severity**: Medium  
+**Status**: Not yet fixed
+
+**Problem**: Daemon auto-answers DA1/DA2 only when `clients.is_empty()`. When a client is attached, the query is silently dropped. Applications that probe terminal identity after attach or after a reset receive no reply, which can cause hangs or incorrect behavior.
+
+**Decision**: Always reply to DA1/DA2 from the daemon, regardless of client attachment state. The daemon intercepts these queries anyway; there is no reason to suppress the reply when clients are present.
+
+**Files to change**: `src/server.rs` (`handle_pty_output`, DA reply block)
+
+---
+
+### 🟡 TODO-3 — Stateful sequences relying solely on passthrough replay
+
+**Severity**: Medium  
+**Status**: Ongoing / gradual improvement
+
+**Problem**: Several long-lived terminal modes survive reconnect only because their raw escape sequences are still in the bounded passthrough queue. If they are evicted (queue full) or if the open/close pair is split across eviction boundaries, the replayed state is inconsistent.
+
+Modes currently at risk:
+- Cursor shape (`DECSCUSR`) — already in passthrough allowlist, but raw replay only
+- Kitty keyboard protocol (`CSI > Ps u` etc.)
+- Focus tracking (`?1004`)
+- Synchronized output (`?2026`)
+- OSC 8 hyperlinks — open/close pairs can be split by eviction
+- Hyperlink state, OSC 7 (working directory)
+
+**Decision**: Promote high-value modes to explicit state fields in `SessionCallbacks`, rather than relying on raw byte retention. Priority order:
+
+1. Cursor shape — track as `Option<u8>` (DECSCUSR `Ps` value)
+2. Kitty keyboard flags — track as bitmask
+3. Focus tracking / synchronized output — track as `bool`
+4. OSC 8 hyperlinks — track as `Option<String>` (current open URI)
+
+**Files to change**: `src/session.rs` (`SessionCallbacks`, `build_snapshot`)
+
+---
+
+### 🟢 TODO-4 — Passthrough overflow in high-OSC workloads
+
+**Severity**: Low (normal Neovim editing), Medium (OSC-heavy apps)  
+**Status**: Logged but not structurally fixed
+
+**Problem**: The 256 seq / 16 KiB FIFO evicts oldest entries first. Normal Neovim editing is unlikely to overflow (cursor-shape changes, title updates, and focus events are sparse). However, terminal apps emitting frequent OSC 8 hyperlinks, OSC 52 clipboard writes, or desktop notifications (OSC 99) can realistically overflow.
+
+**Decision**: The logging added in PR #42 is sufficient for now. When TODO-3 promotes common modes to structured state, overflow risk shrinks naturally. Revisit limits after structured state work lands.
+
+---
+
+### 🟢 TODO-5 — Reconnect regression test coverage
+
+**Severity**: Low  
+**Status**: Not yet added
+
+**Problem**: `vt100`'s `state_formatted()` correctness is assumed. If `vt100` mishandles a sequence internally (emits wrong output), neither the passthrough queue nor the logging catches it.
+
+**Decision**: Add integration-level reconnect tests for real Neovim workflows:
+- Alternate-screen enter/exit (Neovim startup/shutdown)
+- Cursor-shape transitions (normal ↔ insert mode)
+- Hyperlink open/close round-trip
+- Title push/pop stack
+- Resize-after-attach
+
+**Files to change**: `src/session.rs` (test module)
+
+---
+
+## Priority Order
+
+| # | TODO | Severity | Effort | Suggested PR |
+|---|------|----------|--------|--------------|
+| 1 | TODO-2: DA query reply | Medium | Small | Add to `fix/rendering-corruption` |
+| 2 | TODO-1: Multi-client resize | High | Medium | Separate PR after design confirmed |
+| 3 | TODO-3: Structured state for top modes | Medium | Medium–Large | Separate PR per mode |
+| 4 | TODO-5: Reconnect regression tests | Low | Medium | Can accompany TODO-3 PRs |
+| 5 | TODO-4: Passthrough overflow | Low | Deferred | Revisit after TODO-3 |

--- a/docs/adr/0001-rendering-corruption-mitigations.md
+++ b/docs/adr/0001-rendering-corruption-mitigations.md
@@ -1,6 +1,6 @@
 # ADR-0001: Rendering Corruption Mitigations
 
-**Status**: In Progress  
+**Status**: Completed  
 **Branch**: `fix/rendering-corruption`
 
 ---
@@ -34,7 +34,7 @@ On client attach/reconnect, `build_snapshot()` combines both layers and replays 
 
 ---
 
-### 🟡 TODO-1 — Multi-client resize contention
+### ✅ DONE — Multi-client resize contention (TODO-1)
 
 **Severity**: High  
 **Status**: Decided — not yet implemented
@@ -47,7 +47,7 @@ On client attach/reconnect, `build_snapshot()` combines both layers and replays 
 
 ---
 
-### 🟡 TODO-2 — DA1/DA2 queries unanswered while client is attached
+### ✅ DONE — DA1/DA2 queries unanswered while client is attached (TODO-2)
 
 **Severity**: Medium  
 **Status**: Not yet fixed
@@ -60,7 +60,7 @@ On client attach/reconnect, `build_snapshot()` combines both layers and replays 
 
 ---
 
-### 🟡 TODO-3 — Stateful sequences relying solely on passthrough replay
+### ✅ DONE — Stateful sequences relying solely on passthrough replay (TODO-3)
 
 **Severity**: Medium  
 **Status**: Ongoing / gradual improvement

--- a/docs/adr/0001-rendering-corruption-mitigations.md
+++ b/docs/adr/0001-rendering-corruption-mitigations.md
@@ -34,24 +34,16 @@ On client attach/reconnect, `build_snapshot()` combines both layers and replays 
 
 ---
 
-### 🔴 TODO-1 — Multi-client resize contention
+### 🟡 TODO-1 — Multi-client resize contention
 
 **Severity**: High  
-**Status**: Architecture decision required — not yet implemented
+**Status**: Decided — not yet implemented
 
 **Problem**: The session has a single shared PTY. Any client's `RESIZE` changes the PTY dimensions for all clients. Only the resizing client receives a fresh replacement snapshot; other attached clients silently end up with a mismatched terminal size.
 
-**Options**:
+**Decision**: Last-write-wins. The most recent `RESIZE` from any client becomes the authoritative PTY size. All other attached clients receive a replacement snapshot at the new dimensions immediately after the resize.
 
-| Option | Trade-off |
-|--------|-----------|
-| A. Enforce single active display client per session | Simple; matches current real-world usage pattern |
-| B. Authoritative session size; additional clients are watch-only (read-only, no resize) | Allows monitoring from multiple terminals |
-| C. Per-client virtual canvas with server-side reflow | Highest fidelity; large implementation cost |
-
-**Recommended decision**: Option A — document and enforce single-display semantics. Reject or ignore `RESIZE` from a second client if one is already attached as a display client.
-
-**Files to change**: `src/server.rs` (RESIZE handler), `lua/pterm/init.lua` (attach guard), `docs/DESIGN.md`
+**Files to change**: `src/server.rs` (RESIZE handler — broadcast replacement snapshot to all clients, not only the resizing one)
 
 ---
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -204,7 +204,12 @@ impl Server {
 
     /// Send the current terminal snapshot to a specific client and clear its
     /// pending-snapshot flag.
-    fn send_snapshot_to_client(&mut self, client_id: usize) {
+    ///
+    /// When `replace_send_buf` is `true`, any queued outbound bytes for that
+    /// client are dropped first. This is used on RESIZE so an older-size
+    /// snapshot or stale OUTPUT frame cannot remain queued ahead of the fresh
+    /// snapshot for the client's new dimensions.
+    fn send_snapshot_to_client(&mut self, client_id: usize, replace_send_buf: bool) {
         let buffered_pty_bytes = self.pending_pty_output.len();
         let other_pending_snapshots = self
             .clients
@@ -230,6 +235,9 @@ impl Server {
         let snapshot = self.session.snapshot();
         if let Some(client) = self.clients.get_mut(&client_id) {
             client.pending_snapshot = false;
+            if replace_send_buf {
+                client.send_buf.clear();
+            }
             if !snapshot.is_empty() {
                 let msg = proto::encode(proto::server::STATE_SYNC, &snapshot);
                 client.send_buf.extend_from_slice(&msg);
@@ -321,7 +329,7 @@ impl Server {
             .collect();
         for id in &snapshot_ids {
             log::info!("Client {} snapshot triggered by PTY output arrival", *id);
-            self.send_snapshot_to_client(*id);
+            self.send_snapshot_to_client(*id, true);
         }
 
         let msg = proto::encode(proto::server::OUTPUT, &self.pending_pty_output);
@@ -479,16 +487,13 @@ impl Server {
                     };
                     self.session.resize(cols, rows)?;
 
-                    // If this client still has a pending snapshot, the
-                    // session has now been resized to the correct
-                    // dimensions. Generate and send the snapshot.
-                    let needs_snapshot = self
-                        .clients
-                        .get(&client_id)
-                        .map_or(false, |c| c.pending_snapshot);
-                    if needs_snapshot {
-                        self.send_snapshot_to_client(client_id);
-                    }
+                    // Always refresh this client's snapshot after RESIZE.
+                    // If a previous snapshot was already queued but not yet
+                    // fully delivered, keeping it would replay stale
+                    // dimensions into the bridge. Replacing the outbound
+                    // queue keeps the next frame aligned with the client's
+                    // current size.
+                    self.send_snapshot_to_client(client_id, true);
                 }
                 proto::client::DETACH => {}
                 proto::client::REDRAW => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -252,6 +252,13 @@ impl Server {
         }
     }
 
+    fn send_snapshot_to_all_clients(&mut self, replace_send_buf: bool) {
+        let client_ids: Vec<usize> = self.clients.keys().copied().collect();
+        for client_id in client_ids {
+            self.send_snapshot_to_client(client_id, replace_send_buf);
+        }
+    }
+
     fn handle_pty_output(&mut self, buf: &mut [u8]) -> io::Result<()> {
         // Drain all available PTY data (non-blocking) and flush immediately.
         // No timer-based batching — the drain loop itself coalesces all bytes
@@ -279,24 +286,22 @@ impl Server {
                 || (self.clients.len() > 1 && total_pending_da > 0))
         {
             log::warn!(
-                "Observed pending device-attribute queries while {} client(s) are attached (DA1={}, DA2={}); terminal replies will be routed via client INPUT and may be duplicated or misdirected",
+                "Observed pending device-attribute queries while {} client(s) are attached (DA1={}, DA2={})",
                 self.clients.len(),
                 pending_da1,
                 pending_da2
             );
         }
-        if self.clients.is_empty() {
-            for _ in 0..pending_da1 {
-                if let Err(e) = self.session.write_pty(DA1_RESPONSE) {
-                    log::warn!("Failed to write DA1 response to PTY: {}", e);
-                    break;
-                }
+        for _ in 0..pending_da1 {
+            if let Err(e) = self.session.write_pty(DA1_RESPONSE) {
+                log::warn!("Failed to write DA1 response to PTY: {}", e);
+                break;
             }
-            for _ in 0..pending_da2 {
-                if let Err(e) = self.session.write_pty(DA2_RESPONSE) {
-                    log::warn!("Failed to write DA2 response to PTY: {}", e);
-                    break;
-                }
+        }
+        for _ in 0..pending_da2 {
+            if let Err(e) = self.session.write_pty(DA2_RESPONSE) {
+                log::warn!("Failed to write DA2 response to PTY: {}", e);
+                break;
             }
         }
 
@@ -487,13 +492,10 @@ impl Server {
                     };
                     self.session.resize(cols, rows)?;
 
-                    // Always refresh this client's snapshot after RESIZE.
-                    // If a previous snapshot was already queued but not yet
-                    // fully delivered, keeping it would replay stale
-                    // dimensions into the bridge. Replacing the outbound
-                    // queue keeps the next frame aligned with the client's
-                    // current size.
-                    self.send_snapshot_to_client(client_id, true);
+                    // The latest RESIZE is authoritative for every attached
+                    // client. Replacing all outbound queues prevents stale-size
+                    // frames from surviving ahead of the fresh snapshot.
+                    self.send_snapshot_to_all_clients(true);
                 }
                 proto::client::DETACH => {}
                 proto::client::REDRAW => {

--- a/src/session.rs
+++ b/src/session.rs
@@ -577,6 +577,29 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_relies_on_vt100_for_tracked_input_modes() {
+        let mut parser =
+            vt100::Parser::new_with_callbacks(24, 80, 1000, SessionCallbacks::default());
+        parser.process(
+            b"\x1b[?25l\x1b[?2004h\x1b[?1002h\x1b[?1006h\
+              tracked by vt100",
+        );
+
+        assert!(
+            parser.callbacks().passthrough_sequences.is_empty(),
+            "vt100 handles cursor visibility, bracketed paste, and mouse modes"
+        );
+
+        let snapshot = build_snapshot(parser.screen(), parser.callbacks());
+        let snapshot_str = String::from_utf8_lossy(&snapshot);
+
+        assert!(snapshot_str.contains("\x1b[?25l"));
+        assert!(snapshot_str.contains("\x1b[?2004h"));
+        assert!(snapshot_str.contains("\x1b[?1002h"));
+        assert!(snapshot_str.contains("\x1b[?1006h"));
+    }
+
+    #[test]
     fn snapshot_preserves_kitty_keyboard_protocol_sequences() {
         let mut parser = vt100::Parser::new_with_callbacks(
             DEFAULT_TERMINAL_ROWS,

--- a/src/session.rs
+++ b/src/session.rs
@@ -11,6 +11,11 @@ struct SessionCallbacks {
     window_title_stack: Vec<String>,
     pending_da1_queries: usize,
     pending_da2_queries: usize,
+    cursor_shape: Option<u8>,
+    kitty_keyboard_flags: Option<u32>,
+    focus_tracking: bool,
+    synchronized_output: bool,
+    hyperlink_uri: Option<String>,
     passthrough_sequences: VecDeque<Vec<u8>>,
     passthrough_bytes: usize,
 }
@@ -18,15 +23,9 @@ struct SessionCallbacks {
 impl SessionCallbacks {
     const MAX_PASSTHROUGH_SEQUENCES: usize = 256;
     const MAX_PASSTHROUGH_BYTES: usize = 16 * 1024;
-    // DEC private modes that are not fully reconstructed by
-    // `vt100::Screen::state_formatted()`, so snapshot replay needs to emit
-    // their original enable/disable sequences explicitly.
-    //
-    // - `?12`: cursor blink enable/disable
-    // - `?69`: DECLRMM (left/right margin mode)
-    // - `?1004`: focus in/out reporting
-    // - `?2026`: synchronized output mode
-    const PASSTHROUGH_DEC_PRIVATE_MODES: [u16; 4] = [12, 69, 1004, 2026];
+    // DEC private modes not fully reconstructed by `vt100::Screen::state_formatted()`.
+    // Modes 1004 and 2026 are now tracked as explicit struct fields instead.
+    const PASSTHROUGH_DEC_PRIVATE_MODES: [u16; 2] = [12, 69];
 
     fn default_da_params(params: &[&[u16]]) -> bool {
         params.is_empty()
@@ -36,6 +35,10 @@ impl SessionCallbacks {
 
     fn first_param(params: &[&[u16]]) -> Option<u16> {
         params.first().and_then(|param| param.first()).copied()
+    }
+
+    fn first_param_u32(params: &[&[u16]]) -> Option<u32> {
+        Self::first_param(params).map(u32::from)
     }
 
     fn is_passthrough_private_mode(
@@ -214,6 +217,51 @@ impl SessionCallbacks {
         }
         formatted
     }
+
+    fn update_private_mode_state(&mut self, params: &[&[u16]], c: char) -> bool {
+        if !matches!(c, 'h' | 'l') {
+            return false;
+        }
+
+        match Self::first_param(params) {
+            Some(1004) => {
+                self.focus_tracking = c == 'h';
+                true
+            }
+            Some(2026) => {
+                self.synchronized_output = c == 'h';
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn update_kitty_keyboard_state(&mut self, i1: Option<u8>, params: &[&[u16]]) -> bool {
+        match i1 {
+            Some(b'>') | Some(b'=') => {
+                self.kitty_keyboard_flags = Some(Self::first_param_u32(params).unwrap_or(0));
+                true
+            }
+            Some(b'<') => {
+                self.kitty_keyboard_flags = None;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn update_hyperlink_state(&mut self, params: &[&[u8]]) -> bool {
+        if params.first() != Some(&b"8".as_slice()) || params.len() < 3 {
+            return false;
+        }
+
+        if params[2].is_empty() {
+            self.hyperlink_uri = None;
+        } else {
+            self.hyperlink_uri = Some(String::from_utf8_lossy(params[2]).into_owned());
+        }
+        true
+    }
 }
 
 fn build_snapshot(screen: &vt100::Screen, callbacks: &SessionCallbacks) -> Vec<u8> {
@@ -238,6 +286,17 @@ fn build_snapshot(screen: &vt100::Screen, callbacks: &SessionCallbacks) -> Vec<u
     if screen.alternate_screen() {
         prefix.extend_from_slice(b"\x1b[?1049h");
     }
+    if callbacks.focus_tracking {
+        prefix.extend_from_slice(b"\x1b[?1004h");
+    }
+    if callbacks.synchronized_output {
+        prefix.extend_from_slice(b"\x1b[?2026h");
+    }
+    if let Some(uri) = callbacks.hyperlink_uri.as_ref() {
+        prefix.extend_from_slice(b"\x1b]8;;");
+        prefix.extend_from_slice(uri.as_bytes());
+        prefix.extend_from_slice(b"\x1b\\");
+    }
 
     if !prefix.is_empty() {
         prefix.append(&mut snapshot);
@@ -249,6 +308,16 @@ fn build_snapshot(screen: &vt100::Screen, callbacks: &SessionCallbacks) -> Vec<u
     // sequences that state_formatted() emits at the end.
     if !passthrough.is_empty() {
         snapshot.extend_from_slice(&passthrough);
+    }
+    if let Some(ps) = callbacks.cursor_shape {
+        snapshot.extend_from_slice(b"\x1b[");
+        snapshot.extend_from_slice(ps.to_string().as_bytes());
+        snapshot.extend_from_slice(b" q");
+    }
+    if let Some(flags) = callbacks.kitty_keyboard_flags {
+        snapshot.extend_from_slice(b"\x1b[>");
+        snapshot.extend_from_slice(flags.to_string().as_bytes());
+        snapshot.extend_from_slice(b"u");
     }
     snapshot
 }
@@ -267,12 +336,27 @@ impl vt100::Callbacks for SessionCallbacks {
         c: char,
     ) {
         if i1 == Some(b' ') && i2.is_none() && c == 'q' {
+            self.cursor_shape =
+                Self::first_param(params).and_then(|param| u8::try_from(param).ok());
+            return;
+        }
+
+        if i1 == Some(b'?') && i2.is_none() && self.update_private_mode_state(params, c) {
+            if Self::is_passthrough_private_mode(i1, i2, params, c) {
+                self.push_passthrough_sequence(Self::format_unhandled_csi(i1, i2, params, c));
+            }
+            return;
+        }
+
+        if Self::is_kitty_keyboard_protocol(i1, i2, c) {
+            if self.update_kitty_keyboard_state(i1, params) {
+                return;
+            }
             self.push_passthrough_sequence(Self::format_unhandled_csi(i1, i2, params, c));
             return;
         }
 
         if Self::is_passthrough_private_mode(i1, i2, params, c)
-            || Self::is_kitty_keyboard_protocol(i1, i2, c)
             || Self::is_passthrough_sgr_subparams(i1, i2, params, c)
         {
             self.push_passthrough_sequence(Self::format_unhandled_csi(i1, i2, params, c));
@@ -325,6 +409,9 @@ impl vt100::Callbacks for SessionCallbacks {
     }
 
     fn unhandled_osc(&mut self, _: &mut vt100::Screen, params: &[&[u8]]) {
+        if self.update_hyperlink_state(params) {
+            return;
+        }
         if Self::is_passthrough_osc(params) {
             self.push_passthrough_sequence(Self::format_unhandled_osc(params));
         }
@@ -459,12 +546,14 @@ mod tests {
             SessionCallbacks::default(),
         );
         parser.process(b"\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\");
+        parser.process(b"\x1b]1337;Custom=1\x1b\\");
 
         let snapshot = build_snapshot(parser.screen(), parser.callbacks());
         let snapshot = String::from_utf8_lossy(&snapshot);
 
-        assert!(snapshot.contains("\x1b]8;;https://example.com\x1b\\"));
-        assert!(snapshot.contains("\x1b]8;;\x1b\\"));
+        assert!(!snapshot.contains("\x1b]8;;https://example.com\x1b\\"));
+        assert!(!snapshot.contains("\x1b]8;;\x1b\\"));
+        assert!(snapshot.contains("\x1b]1337;Custom=1\x1b\\"));
     }
 
     #[test]
@@ -509,6 +598,9 @@ mod tests {
             SessionCallbacks::default(),
         );
         parser.process(b"\x1b[6 q");
+
+        assert!(parser.callbacks().passthrough_sequences.is_empty());
+        assert_eq!(parser.callbacks().cursor_shape, Some(6));
 
         let snapshot = build_snapshot(parser.screen(), parser.callbacks());
         let snapshot = String::from_utf8_lossy(&snapshot);
@@ -568,6 +660,10 @@ mod tests {
             SessionCallbacks::default(),
         );
         parser.process(b"\x1b[?1004h\x1b[?2026h");
+
+        assert!(parser.callbacks().passthrough_sequences.is_empty());
+        assert!(parser.callbacks().focus_tracking);
+        assert!(parser.callbacks().synchronized_output);
 
         let snapshot = build_snapshot(parser.screen(), parser.callbacks());
         let snapshot_str = String::from_utf8_lossy(&snapshot);
@@ -635,10 +731,43 @@ mod tests {
         let snapshot = build_snapshot(parser.screen(), parser.callbacks());
         let snapshot_str = String::from_utf8_lossy(&snapshot);
 
-        assert!(snapshot_str.contains("\x1b[>1u"));
-        assert!(snapshot_str.contains("\x1b[=5u"));
-        assert!(snapshot_str.contains("\x1b[<u"));
+        assert!(!snapshot_str.contains("\x1b[>1u"));
+        assert!(!snapshot_str.contains("\x1b[=5u"));
+        assert!(!snapshot_str.contains("\x1b[<u"));
+        assert_eq!(parser.callbacks().kitty_keyboard_flags, None);
         assert_eq!(parser.callbacks().pending_da2_queries, 0);
+    }
+
+    #[test]
+    fn snapshot_replays_latest_kitty_keyboard_flags() {
+        let mut parser =
+            vt100::Parser::new_with_callbacks(24, 80, 1000, SessionCallbacks::default());
+        parser.process(b"\x1b[=3u\x1b[>7u");
+
+        assert_eq!(parser.callbacks().kitty_keyboard_flags, Some(7));
+
+        let snapshot = build_snapshot(parser.screen(), parser.callbacks());
+        let snapshot_str = String::from_utf8_lossy(&snapshot);
+
+        assert!(snapshot_str.contains("\x1b[>7u"));
+        assert!(!snapshot_str.contains("\x1b[=3u"));
+    }
+
+    #[test]
+    fn snapshot_replays_open_hyperlink_only() {
+        let mut parser =
+            vt100::Parser::new_with_callbacks(24, 80, 1000, SessionCallbacks::default());
+        parser.process(b"\x1b]8;;https://example.com\x1b\\link");
+
+        assert_eq!(
+            parser.callbacks().hyperlink_uri.as_deref(),
+            Some("https://example.com")
+        );
+
+        let snapshot = build_snapshot(parser.screen(), parser.callbacks());
+        let snapshot_str = String::from_utf8_lossy(&snapshot);
+
+        assert!(snapshot_str.contains("\x1b]8;;https://example.com\x1b\\"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix RESIZE stale-buffer race: clear client send buffer and issue fresh snapshot on every RESIZE
- Fix RESIZE broadcast: send replacement snapshot to ALL attached clients on RESIZE (last-write-wins)
- Fix DA1/DA2: always reply regardless of client attachment state
- Promote stateful sequences to structured state in `SessionCallbacks`: cursor shape, Kitty keyboard flags, focus tracking, synchronized output, OSC 8 hyperlink URI — no longer dependent on passthrough queue survival
- Add `docs/adr/0001-rendering-corruption-mitigations.md`: full analysis and decision record

## Checklist

- [x] Tests: added — kitty keyboard flag replay, open hyperlink replay, vt100 mode tracking
- [x] Docs: added — ADR-0001
- [x] Breaking change: no