### PR TITLE
fix: trigger auto redraw immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ require("pterm").setup({
   -- Automatically redraw on BufEnter / TermEnter to recover from rendering
   -- corruption that can occur during mode or window focus switches.
   auto_redraw = true,
-  -- Debounce delay in milliseconds for automatic redraws.
+  -- Cooldown window in milliseconds for automatic redraws. The first
+  -- BufEnter / TermEnter redraw fires immediately; repeated events are
+  -- suppressed until the cooldown expires.
   auto_redraw_delay_ms = 1000,
 })
 ```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -5,7 +5,7 @@
 | Option | Default | Description |
 |---|---|---|
 | `auto_redraw` | `true` | Automatically redraw on `BufEnter` / `TermEnter` to recover from rendering corruption during mode or window focus switches |
-| `auto_redraw_delay_ms` | `1000` | Debounce delay (ms) for automatic redraws |
+| `auto_redraw_delay_ms` | `1000` | Cooldown window (ms) after an automatic redraw; the first `BufEnter` / `TermEnter` redraw fires immediately and repeated events are suppressed until the cooldown expires |
 | `socket_dir` | `nil` | Override socket directory (nil = let daemon decide) |
 
 ## Environment variables

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -15,6 +15,14 @@ local connections = {}
 local redraw_timers = {}
 local cached_binary = nil
 
+local function trigger_redraw(session_name)
+	local conn = connections[session_name]
+	if conn and conn.job_id then
+		local bin = find_binary()
+		vim.fn.jobstart({ bin, "redraw", session_name })
+	end
+end
+
 --- Find the pterm binary (result is cached after the first successful lookup).
 local function find_binary()
 	if cached_binary then
@@ -178,10 +186,11 @@ local function schedule_redraw(session_name, delay_ms)
 	delay_ms = delay_ms or M.config.auto_redraw_delay_ms
 	local existing = redraw_timers[session_name]
 	if existing then
-		existing:stop()
-		existing:close()
-		redraw_timers[session_name] = nil
+		return
 	end
+
+	trigger_redraw(session_name)
+
 	local timer = vim.uv.new_timer()
 	redraw_timers[session_name] = timer
 	timer:start(
@@ -194,11 +203,6 @@ local function schedule_redraw(session_name, delay_ms)
 			redraw_timers[session_name] = nil
 			timer:stop()
 			timer:close()
-			local conn = connections[session_name]
-			if conn and conn.job_id then
-				local bin = find_binary()
-				vim.fn.jobstart({ bin, "redraw", session_name })
-			end
 		end)
 	)
 end


### PR DESCRIPTION
## Summary
- change automatic redraw scheduling from trailing debounce to immediate leading-edge trigger with a cooldown
- avoid delaying the first BufEnter / TermEnter recovery redraw
- update README and configuration docs to describe the new cooldown behavior

## Testing
- stylua --check lua/pterm/init.lua