### PR TITLE
fix: move find_binary before trigger_redraw to fix nil call error

### DIFF
--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -15,14 +15,6 @@ local connections = {}
 local redraw_timers = {}
 local cached_binary = nil
 
-local function trigger_redraw(session_name)
-	local conn = connections[session_name]
-	if conn and conn.job_id then
-		local bin = find_binary()
-		vim.fn.jobstart({ bin, "redraw", session_name })
-	end
-end
-
 --- Find the pterm binary (result is cached after the first successful lookup).
 local function find_binary()
 	if cached_binary then
@@ -54,6 +46,14 @@ local function find_binary()
 	end
 
 	error("pterm binary not found. Install pterm with Nix or build it in this repository.")
+end
+
+local function trigger_redraw(session_name)
+	local conn = connections[session_name]
+	if conn and conn.job_id then
+		local bin = find_binary()
+		vim.fn.jobstart({ bin, "redraw", session_name })
+	end
 end
 
 --- Get socket directory (must match daemon's socket_dir() logic).


### PR DESCRIPTION
## Summary

- `trigger_redraw` が `find_binary` より前に定義されていたため、Lua のスコープ規則でglobal変数として解釈され `nil` になっていた
- PR #47 (`fix: trigger auto redraw immediately`) で `schedule_redraw` 内から `trigger_redraw` を即時呼び出すようになり、潜在していた順序バグが顕在化
- `find_binary` の定義を `trigger_redraw` より前に移動することで修正

## Test plan

- [ ] pterm セッションを開いた状態で Telescope を起動・終了して `find_binary` nil エラーが出ないことを確認
- [ ] TermEnter / BufEnter 時に auto redraw が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)