### PR TITLE
chore(actions): update app token action for Node 24

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,15 @@ jobs:
 
       - name: Extract version from branch name
         id: version
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
           VERSION="${BRANCH#release/}"
           echo "tag=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- update actions/create-github-app-token from v2 to v3 in release workflows for Node 24 support
- avoid direct interpolation of the pull request branch name in the release workflow shell script

## Verification
- actionlint .github/workflows/release-prep.yml .github/workflows/release.yml