### PR TITLE
fix(nvim): preserve global window option defaults

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,9 @@
 
   nixConfig = {
     extra-substituters = [ "https://ttak0422-pterm.cachix.org" ];
-    extra-trusted-public-keys = [ "ttak0422-pterm.cachix.org-1:s0zSh4J7l8NrisVESCYNxcSw7rz2vLsGa5fh+E42NDY=" ];
+    extra-trusted-public-keys = [
+      "ttak0422-pterm.cachix.org-1:s0zSh4J7l8NrisVESCYNxcSw7rz2vLsGa5fh+E42NDY="
+    ];
   };
 
   inputs = {

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -207,6 +207,23 @@ local function schedule_redraw(session_name, delay_ms)
 	)
 end
 
+local function with_preserved_global_options(option_names, callback)
+	local saved = {}
+	for _, name in ipairs(option_names) do
+		saved[name] = vim.go[name]
+	end
+
+	local ok, err = pcall(callback)
+
+	for _, name in ipairs(option_names) do
+		vim.go[name] = saved[name]
+	end
+
+	if not ok then
+		error(err)
+	end
+end
+
 --- Internal: create a terminal buffer and start a pterm bridge process.
 --- `cmd` is the full argv for jobstart (e.g. {"pterm","open","main"}).
 local function start_terminal(session_name, cmd)
@@ -227,9 +244,11 @@ local function start_terminal(session_name, cmd)
 	local win = vim.api.nvim_get_current_win()
 	vim.api.nvim_set_option_value("number", false, { win = win })
 	vim.api.nvim_set_option_value("relativenumber", false, { win = win })
-	vim.api.nvim_set_option_value("signcolumn", "no", { win = win })
-	vim.api.nvim_set_option_value("foldcolumn", "0", { win = win })
-	vim.api.nvim_set_option_value("statuscolumn", "", { win = win })
+	with_preserved_global_options({ "signcolumn", "foldcolumn", "statuscolumn" }, function()
+		vim.api.nvim_set_option_value("signcolumn", "no", { win = win })
+		vim.api.nvim_set_option_value("foldcolumn", "0", { win = win })
+		vim.api.nvim_set_option_value("statuscolumn", "", { win = win })
+	end)
 
 	-- Let the bridge read the actual PTY size via TIOCGWINSZ instead of
 	-- passing --cols/--rows from Lua.  jobstart({term=true}) creates a PTY

--- a/src/session.rs
+++ b/src/session.rs
@@ -223,7 +223,7 @@ impl SessionCallbacks {
         // information. Replaying them from a snapshot would trigger a fresh
         // query against the client terminal, and its reply can then be
         // forwarded into the PTY as if it were user input.
-        !params.last().is_some_and(|param| *param == b"?")
+        params.last().is_none_or(|param| *param != b"?")
     }
 
     fn format_clipboard_copy(screen: &[u8], data: &[u8]) -> Vec<u8> {
@@ -644,7 +644,7 @@ impl TerminalOutputFilter {
         };
         let body = &seq[2..end];
         body.split(|&byte| byte == b';')
-            .last()
+            .next_back()
             .is_some_and(|param| param == b"?")
     }
 }


### PR DESCRIPTION
## Summary
- preserve Neovim global-local option defaults while applying pterm terminal window options
- keep pterm buffers local-only for signcolumn/foldcolumn/statuscolumn so later windows do not inherit hidden columns
- apply current formatter/clippy fixes needed by the flake checks

## Context
`nvim_set_option_value(..., { win = win })` still changes the global default for global-local options such as `signcolumn`, `foldcolumn`, and `statuscolumn` in current Neovim. Opening a pterm buffer could leave `vim.go.signcolumn` as `no`, so later normal buffers could unexpectedly lose their sign column.

## Verification
- `stylua lua/pterm/init.lua`
- Neovim smoke check: opening a pterm session keeps `vim.go.signcolumn=yes` while `vim.wo.signcolumn=no` for the pterm window
- `nix flake check --no-write-lock-file --print-build-logs`
