### PR TITLE
Add diagnostic state dump command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ pterm socket mysession
 # Redraw terminal (resend snapshot to all clients)
 pterm redraw mysession
 
+# Print diagnostic state dump as JSON
+pterm dump mysession
+
 # Kill a session
 pterm kill mysession
 ```
@@ -47,12 +50,13 @@ pterm kill parent          # kills parent and parent/child
 :Pterm dev zsh      " opens/creates session with custom command
 :PtermList          " list sessions
 :PtermRedraw dev    " redraw a session
+:PtermDump dev      " open diagnostic state dump as JSON
 :PtermKill dev      " kill a session
 ```
 
 `pterm` opens a terminal buffer backed by `jobstart({ "pterm", "attach", <name> }, { term = true })`.
 
-The Lua module also exports functions for programmatic use: `open`, `attach`, `detach`, `list`, `kill`, `redraw`.
+The Lua module also exports functions for programmatic use: `open`, `attach`, `detach`, `list`, `kill`, `redraw`, `dump`.
 
 ## Requirements
 

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -470,6 +470,38 @@ function M.snapshot_text(session_name)
 	return (output:gsub("\n$", ""))
 end
 
+--- Return a diagnostic state dump as JSON.
+function M.dump(session_name)
+	if not session_name or session_name == "" then
+		return nil, "Session name required"
+	end
+
+	local bin = find_binary()
+	local output = vim.fn.system({ bin, "dump", session_name })
+	if vim.v.shell_error ~= 0 then
+		return nil, output
+	end
+
+	return (output:gsub("\n$", ""))
+end
+
+local function open_dump_buffer(session_name, dump)
+	local buf_name = "pterm-dump://" .. session_name
+	local existing = vim.fn.bufnr(buf_name)
+	if existing ~= -1 then
+		pcall(vim.api.nvim_buf_delete, existing, { force = true })
+	end
+
+	local buf = vim.api.nvim_create_buf(true, true)
+	vim.api.nvim_buf_set_name(buf, buf_name)
+	vim.api.nvim_set_option_value("buftype", "nofile", { buf = buf })
+	vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = buf })
+	vim.api.nvim_set_option_value("swapfile", false, { buf = buf })
+	vim.api.nvim_set_option_value("filetype", "json", { buf = buf })
+	vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(dump, "\n", { plain = true }))
+	vim.api.nvim_set_current_buf(buf)
+end
+
 --- Setup function for lazy.nvim / packer etc.
 function M.setup(opts)
 	M.config = vim.tbl_deep_extend("force", M.config, opts or {})
@@ -512,6 +544,24 @@ function M.setup(opts)
 		nargs = 1,
 		complete = complete_sessions,
 		desc = "Redraw a persistent terminal session",
+	})
+
+	vim.api.nvim_create_user_command("PtermDump", function(cmd_opts)
+		local session_name = cmd_opts.fargs[1]
+		local dump, err = M.dump(session_name)
+		if not dump then
+			vim.notify(
+				"Failed to dump session '" .. session_name .. "': " .. vim.trim(tostring(err or "")),
+				vim.log.levels.ERROR
+			)
+			return
+		end
+
+		open_dump_buffer(session_name, dump)
+	end, {
+		nargs = 1,
+		complete = complete_sessions,
+		desc = "Open a diagnostic dump for a persistent terminal session",
 	})
 
 	vim.api.nvim_create_user_command("PtermKill", function(cmd_opts)

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -28,6 +28,9 @@ pub mod client {
 
     /// Request terminal redraw (no payload)
     pub const REDRAW: u8 = 0x04;
+
+    /// Request a diagnostic dump of the daemon-side terminal state (no payload)
+    pub const DUMP: u8 = 0x05;
 }
 
 /// Daemon → Client message types
@@ -43,6 +46,10 @@ pub mod server {
     /// Terminal state snapshot (sent on initial attach)
     /// Payload: escape sequences reproducing current terminal state
     pub const STATE_SYNC: u8 = 0x80;
+
+    /// Diagnostic dump of the daemon-side terminal state
+    /// Payload: UTF-8 JSON
+    pub const DUMP: u8 = 0x81;
 }
 
 /// Encode a framed message into a Vec<u8>.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod session;
 use crate::paths::{find_sessions, session_dir, session_socket_path, socket_dir, SOCKET_FILENAME};
 use server::Server;
 use session::Session;
-use std::io;
+use std::io::{self, Read, Write};
 use std::os::unix::fs::FileTypeExt;
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -26,6 +26,7 @@ Usage:
   pterm list   [prefix]
   pterm kill   <session-name>
   pterm redraw <session-name>   # redraw terminal (resend snapshot)
+  pterm dump   <session-name>   # print diagnostic state dump as JSON
   pterm socket <session-name>   # print socket path
 
 Session names may contain '/' for hierarchical sessions:
@@ -306,6 +307,60 @@ fn cmd_redraw(args: &[String]) -> io::Result<()> {
     Ok(())
 }
 
+fn cmd_dump(args: &[String]) -> io::Result<()> {
+    let name = args.first().map(|s| s.as_str()).unwrap_or_else(|| {
+        eprintln!("Error: session name required");
+        std::process::exit(1);
+    });
+
+    let sock = session_socket_path(name);
+    if !sock.exists() {
+        eprintln!("Error: session '{}' not found", name);
+        std::process::exit(1);
+    }
+
+    let mut stream = std::os::unix::net::UnixStream::connect(&sock)?;
+    stream.set_read_timeout(Some(Duration::from_secs(3)))?;
+    let msg = pterm_proto::encode(pterm_proto::client::DUMP, &[]);
+    stream.write_all(&msg)?;
+
+    let mut recv_buf = Vec::new();
+    let mut read_buf = vec![0u8; 65536];
+    loop {
+        match stream.read(&mut read_buf) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "daemon closed connection before sending dump",
+                ));
+            }
+            Ok(n) => {
+                recv_buf.extend_from_slice(&read_buf[..n]);
+                for frame in pterm_proto::decode_frames(&mut recv_buf) {
+                    if frame.msg_type == pterm_proto::server::DUMP {
+                        let mut stdout = io::stdout().lock();
+                        stdout.write_all(&frame.payload)?;
+                        stdout.write_all(b"\n")?;
+                        return Ok(());
+                    }
+                }
+            }
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+                ) =>
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "timed out waiting for dump response",
+                ));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
 fn cmd_socket(args: &[String]) -> io::Result<()> {
     let name = args.first().map(|s| s.as_str()).unwrap_or_else(|| {
         eprintln!("Error: session name required");
@@ -332,6 +387,7 @@ fn main() {
         "list" | "ls" => cmd_list(&args[2..]),
         "kill" => cmd_kill(&args[2..]),
         "redraw" => cmd_redraw(&args[2..]),
+        "dump" => cmd_dump(&args[2..]),
         "socket" => cmd_socket(&args[2..]),
         "-h" | "--help" | "help" => {
             print_usage();

--- a/src/server.rs
+++ b/src/server.rs
@@ -23,6 +23,8 @@ struct Client {
     large_send_buf_warned: bool,
     /// `true` until the initial snapshot has been sent.
     pending_snapshot: bool,
+    /// One-shot diagnostic clients should not receive normal terminal output.
+    diagnostic: bool,
 }
 
 pub struct Server {
@@ -192,6 +194,7 @@ impl Server {
                             send_buf: Vec::new(),
                             large_send_buf_warned: false,
                             pending_snapshot: true,
+                            diagnostic: false,
                         },
                     );
                 }
@@ -260,9 +263,18 @@ impl Server {
     }
 
     fn handle_pty_output(&mut self, buf: &mut [u8]) -> io::Result<()> {
-        // Drain all available PTY data (non-blocking) and flush immediately.
-        // No timer-based batching — the drain loop itself coalesces all bytes
-        // that are available at this instant.
+        self.drain_pty_output(buf)?;
+
+        if !self.pending_pty_output.is_empty() {
+            self.flush_pty_output();
+        }
+
+        Ok(())
+    }
+
+    fn drain_pty_output(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        // Drain all available PTY data (non-blocking). No timer-based batching
+        // -- the drain loop itself coalesces all bytes available right now.
         loop {
             match self.session.read_pty(buf) {
                 Ok(0) => break,
@@ -324,10 +336,6 @@ impl Server {
             }
         }
 
-        if !self.pending_pty_output.is_empty() {
-            self.flush_pty_output();
-        }
-
         Ok(())
     }
 
@@ -349,7 +357,13 @@ impl Server {
         let snapshot_ids: Vec<usize> = self
             .clients
             .iter()
-            .filter_map(|(&id, c)| if c.pending_snapshot { Some(id) } else { None })
+            .filter_map(|(&id, c)| {
+                if c.pending_snapshot && !c.diagnostic {
+                    Some(id)
+                } else {
+                    None
+                }
+            })
             .collect();
         for id in &snapshot_ids {
             log::info!("Client {} snapshot triggered by PTY output arrival", *id);
@@ -362,6 +376,9 @@ impl Server {
         let mut disconnected = Vec::new();
         let mut flush_ids = Vec::new();
         for (&id, client) in self.clients.iter_mut() {
+            if client.diagnostic {
+                continue;
+            }
             // Skip clients that just received a snapshot — they already have
             // the up-to-date screen state and must not get the raw bytes again.
             if snapshot_ids.contains(&id) {
@@ -523,6 +540,29 @@ impl Server {
                     redraw_data.extend_from_slice(&self.session.snapshot());
                     let msg = proto::encode(proto::server::STATE_SYNC, &redraw_data);
                     for (_, client) in self.clients.iter_mut() {
+                        client.send_buf.extend_from_slice(&msg);
+                    }
+                    flush_all = true;
+                }
+                proto::client::DUMP => {
+                    log::info!("Dump requested by client {}", client_id);
+                    if let Some(client) = self.clients.get_mut(&client_id) {
+                        client.diagnostic = true;
+                        client.pending_snapshot = false;
+                        client.send_buf.clear();
+                    }
+
+                    let mut pty_buf = vec![0u8; 65536];
+                    self.drain_pty_output(&mut pty_buf)?;
+                    if !self.pending_pty_output.is_empty() {
+                        self.flush_pty_output();
+                    }
+
+                    let payload = serde_json::to_vec_pretty(&self.session.dump())
+                        .map_err(io::Error::other)?;
+                    let msg = proto::encode(proto::server::DUMP, &payload);
+                    if let Some(client) = self.clients.get_mut(&client_id) {
+                        client.send_buf.clear();
                         client.send_buf.extend_from_slice(&msg);
                     }
                     flush_all = true;

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,6 +1,7 @@
 use crate::constants::{DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS};
 use crate::pty::Pty;
 use nix::sys::termios;
+use serde::Serialize;
 use std::collections::VecDeque;
 use std::fmt::Write as _;
 use std::io;
@@ -31,6 +32,118 @@ struct KittyKeyboardState {
 struct ScreenKittyKeyboardStates {
     main: KittyKeyboardState,
     alternate: KittyKeyboardState,
+}
+
+#[derive(Serialize)]
+pub struct SessionDump {
+    schema_version: u8,
+    session: String,
+    screen: ScreenDump,
+    tracked: TrackedStateDump,
+    snapshot: BytesDump,
+}
+
+#[derive(Serialize)]
+struct ScreenDump {
+    size: SizeDump,
+    cursor: CursorDump,
+    scrollback: usize,
+    modes: ScreenModesDump,
+    active_attrs: CellAttrsDump,
+    rows: Vec<RowDump>,
+}
+
+#[derive(Serialize)]
+struct SizeDump {
+    rows: u16,
+    cols: u16,
+}
+
+#[derive(Serialize)]
+struct CursorDump {
+    row: u16,
+    col: u16,
+}
+
+#[derive(Serialize)]
+struct ScreenModesDump {
+    alternate_screen: bool,
+    application_keypad: bool,
+    application_cursor: bool,
+    hide_cursor: bool,
+    bracketed_paste: bool,
+    mouse_protocol_mode: String,
+    mouse_protocol_encoding: String,
+}
+
+#[derive(Serialize)]
+struct RowDump {
+    row: u16,
+    wrapped: bool,
+    text: String,
+    cells: Vec<CellDump>,
+}
+
+#[derive(Serialize)]
+struct CellDump {
+    col: u16,
+    text: String,
+    wide: bool,
+    wide_continuation: bool,
+    attrs: CellAttrsDump,
+}
+
+#[derive(Serialize, PartialEq, Eq)]
+struct CellAttrsDump {
+    fg: ColorDump,
+    bg: ColorDump,
+    bold: bool,
+    dim: bool,
+    italic: bool,
+    underline: bool,
+    inverse: bool,
+}
+
+#[derive(Serialize, PartialEq, Eq)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+enum ColorDump {
+    Default,
+    Index(u8),
+    Rgb { r: u8, g: u8, b: u8 },
+}
+
+#[derive(Serialize)]
+struct TrackedStateDump {
+    window_title: Option<String>,
+    window_title_stack: Vec<String>,
+    pending_da1_queries: usize,
+    pending_da2_queries: usize,
+    cursor_shape: Option<u8>,
+    kitty_keyboard: ScreenKittyKeyboardStatesDump,
+    focus_tracking: bool,
+    synchronized_output: bool,
+    hyperlink_uri: Option<String>,
+    passthrough_sequences: Vec<BytesDump>,
+    passthrough_bytes: usize,
+}
+
+#[derive(Serialize)]
+struct ScreenKittyKeyboardStatesDump {
+    main: KittyKeyboardStateDump,
+    alternate: KittyKeyboardStateDump,
+}
+
+#[derive(Serialize)]
+struct KittyKeyboardStateDump {
+    flags: u32,
+    stack: Vec<u32>,
+}
+
+#[derive(Serialize)]
+struct BytesDump {
+    len: usize,
+    escaped: String,
+    hex: String,
 }
 
 impl SessionCallbacks {
@@ -320,6 +433,184 @@ impl SessionCallbacks {
             self.hyperlink_uri = Some(String::from_utf8_lossy(params[2]).into_owned());
         }
         true
+    }
+
+    fn dump(&self) -> TrackedStateDump {
+        TrackedStateDump {
+            window_title: self.window_title.clone(),
+            window_title_stack: self.window_title_stack.clone(),
+            pending_da1_queries: self.pending_da1_queries,
+            pending_da2_queries: self.pending_da2_queries,
+            cursor_shape: self.cursor_shape,
+            kitty_keyboard: ScreenKittyKeyboardStatesDump {
+                main: self.kitty_keyboard_states.main.dump(),
+                alternate: self.kitty_keyboard_states.alternate.dump(),
+            },
+            focus_tracking: self.focus_tracking,
+            synchronized_output: self.synchronized_output,
+            hyperlink_uri: self.hyperlink_uri.clone(),
+            passthrough_sequences: self
+                .passthrough_sequences
+                .iter()
+                .map(|seq| BytesDump::new(seq))
+                .collect(),
+            passthrough_bytes: self.passthrough_bytes,
+        }
+    }
+}
+
+impl KittyKeyboardState {
+    fn dump(&self) -> KittyKeyboardStateDump {
+        KittyKeyboardStateDump {
+            flags: self.flags,
+            stack: self.stack.iter().copied().collect(),
+        }
+    }
+}
+
+impl BytesDump {
+    fn new(bytes: &[u8]) -> Self {
+        Self {
+            len: bytes.len(),
+            escaped: escape_bytes(bytes),
+            hex: format_bytes_hex(bytes),
+        }
+    }
+}
+
+impl ColorDump {
+    fn new(color: vt100::Color) -> Self {
+        match color {
+            vt100::Color::Default => Self::Default,
+            vt100::Color::Idx(idx) => Self::Index(idx),
+            vt100::Color::Rgb(r, g, b) => Self::Rgb { r, g, b },
+        }
+    }
+}
+
+impl CellAttrsDump {
+    fn from_cell(cell: &vt100::Cell) -> Self {
+        Self {
+            fg: ColorDump::new(cell.fgcolor()),
+            bg: ColorDump::new(cell.bgcolor()),
+            bold: cell.bold(),
+            dim: cell.dim(),
+            italic: cell.italic(),
+            underline: cell.underline(),
+            inverse: cell.inverse(),
+        }
+    }
+
+    fn from_screen(screen: &vt100::Screen) -> Self {
+        Self {
+            fg: ColorDump::new(screen.fgcolor()),
+            bg: ColorDump::new(screen.bgcolor()),
+            bold: screen.bold(),
+            dim: screen.dim(),
+            italic: screen.italic(),
+            underline: screen.underline(),
+            inverse: screen.inverse(),
+        }
+    }
+}
+
+impl Default for CellAttrsDump {
+    fn default() -> Self {
+        Self {
+            fg: ColorDump::Default,
+            bg: ColorDump::Default,
+            bold: false,
+            dim: false,
+            italic: false,
+            underline: false,
+            inverse: false,
+        }
+    }
+}
+
+fn escape_bytes(bytes: &[u8]) -> String {
+    let mut escaped = String::new();
+    for &byte in bytes {
+        match byte {
+            b'\x1b' => escaped.push_str("\\e"),
+            b'\n' => escaped.push_str("\\n"),
+            b'\r' => escaped.push_str("\\r"),
+            b'\t' => escaped.push_str("\\t"),
+            b'\\' => escaped.push_str("\\\\"),
+            b'"' => escaped.push_str("\\\""),
+            0x20..=0x7e => escaped.push(byte as char),
+            _ => {
+                let _ = write!(&mut escaped, "\\x{byte:02x}");
+            }
+        }
+    }
+    escaped
+}
+
+fn format_bytes_hex(bytes: &[u8]) -> String {
+    let mut formatted = String::with_capacity(bytes.len().saturating_mul(2));
+    for byte in bytes {
+        let _ = write!(&mut formatted, "{byte:02x}");
+    }
+    formatted
+}
+
+fn dump_screen(screen: &vt100::Screen) -> ScreenDump {
+    let (rows, cols) = screen.size();
+    let (cursor_row, cursor_col) = screen.cursor_position();
+    let default_attrs = CellAttrsDump::default();
+    let text_rows: Vec<String> = screen.rows(0, cols).collect();
+    let mut rows_dump = Vec::with_capacity(usize::from(rows));
+
+    for row in 0..rows {
+        let mut cells = Vec::new();
+        for col in 0..cols {
+            let Some(cell) = screen.cell(row, col) else {
+                continue;
+            };
+            let attrs = CellAttrsDump::from_cell(cell);
+            if !cell.has_contents()
+                && !cell.is_wide()
+                && !cell.is_wide_continuation()
+                && attrs == default_attrs
+            {
+                continue;
+            }
+            cells.push(CellDump {
+                col,
+                text: cell.contents().to_string(),
+                wide: cell.is_wide(),
+                wide_continuation: cell.is_wide_continuation(),
+                attrs,
+            });
+        }
+
+        rows_dump.push(RowDump {
+            row,
+            wrapped: screen.row_wrapped(row),
+            text: text_rows.get(usize::from(row)).cloned().unwrap_or_default(),
+            cells,
+        });
+    }
+
+    ScreenDump {
+        size: SizeDump { rows, cols },
+        cursor: CursorDump {
+            row: cursor_row,
+            col: cursor_col,
+        },
+        scrollback: screen.scrollback(),
+        modes: ScreenModesDump {
+            alternate_screen: screen.alternate_screen(),
+            application_keypad: screen.application_keypad(),
+            application_cursor: screen.application_cursor(),
+            hide_cursor: screen.hide_cursor(),
+            bracketed_paste: screen.bracketed_paste(),
+            mouse_protocol_mode: format!("{:?}", screen.mouse_protocol_mode()),
+            mouse_protocol_encoding: format!("{:?}", screen.mouse_protocol_encoding()),
+        },
+        active_attrs: CellAttrsDump::from_screen(screen),
+        rows: rows_dump,
     }
 }
 
@@ -731,6 +1022,18 @@ impl Session {
         build_snapshot(self.parser.screen(), self.parser.callbacks())
     }
 
+    /// Build a structured diagnostic dump of the daemon-side terminal state.
+    pub fn dump(&self) -> SessionDump {
+        let snapshot = self.snapshot();
+        SessionDump {
+            schema_version: 1,
+            session: self.name.clone(),
+            screen: dump_screen(self.parser.screen()),
+            tracked: self.parser.callbacks().dump(),
+            snapshot: BytesDump::new(&snapshot),
+        }
+    }
+
     pub fn take_pending_da_queries(&mut self) -> (usize, usize) {
         self.parser.callbacks_mut().take_pending_da_queries()
     }
@@ -765,9 +1068,39 @@ impl Session {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_snapshot, KittyKeyboardState, SessionCallbacks, TerminalOutputFilter};
+    use super::{
+        build_snapshot, dump_screen, BytesDump, KittyKeyboardState, SessionCallbacks,
+        TerminalOutputFilter,
+    };
     use crate::constants::{DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS};
     use std::collections::VecDeque;
+
+    #[test]
+    fn dump_screen_includes_rows_cells_and_attributes() {
+        let mut parser = vt100::Parser::new(DEFAULT_TERMINAL_ROWS, DEFAULT_TERMINAL_COLS, 1000);
+        parser.process(b"plain \x1b[31mred");
+
+        let dump = dump_screen(parser.screen());
+        assert_eq!(dump.size.rows, DEFAULT_TERMINAL_ROWS);
+        assert_eq!(dump.size.cols, DEFAULT_TERMINAL_COLS);
+        assert!(dump.rows[0].text.contains("plain red"));
+
+        let red_cell = dump.rows[0]
+            .cells
+            .iter()
+            .find(|cell| cell.col == 6)
+            .expect("red cell should be present in dump");
+        assert_eq!(red_cell.text, "r");
+        assert!(matches!(red_cell.attrs.fg, super::ColorDump::Index(1)));
+    }
+
+    #[test]
+    fn bytes_dump_uses_debuggable_escape_and_hex_forms() {
+        let dump = BytesDump::new(b"\x1b[31m\r\n");
+        assert_eq!(dump.len, 7);
+        assert_eq!(dump.escaped, "\\e[31m\\r\\n");
+        assert_eq!(dump.hex, "1b5b33316d0d0a");
+    }
 
     #[test]
     fn snapshot_preserves_unhandled_osc_sequences() {


### PR DESCRIPTION
## Summary
- add protocol frames for one-shot diagnostic dump requests
- add `pterm dump <session-name>` to print daemon-side terminal state as pretty JSON
- include screen rows/cells/attributes, tracked terminal metadata, and snapshot bytes in escaped/hex forms

## Tests
- cargo fmt --check
- cargo test
- cargo build