### PR TITLE
Add Telescope session previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ require("telescope").load_extension("pterm")
 ```
 
 Connected sessions are shown with a `[connected]` prefix.
+The preview pane shows the tail of each session's current terminal screen,
+trimmed to the preview width.
 If no existing session matches the current Telescope query, pressing `Enter`
 creates or opens a session using the prompt text as the session name.
 

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -455,6 +455,21 @@ function M.redraw(session_name)
 	end
 end
 
+--- Return a plain-text snapshot of the visible terminal screen.
+function M.snapshot_text(session_name)
+	if not session_name or session_name == "" then
+		return nil, "Session name required"
+	end
+
+	local bin = find_binary()
+	local output = vim.fn.system({ bin, "snapshot-text", session_name })
+	if vim.v.shell_error ~= 0 then
+		return nil, output
+	end
+
+	return (output:gsub("\n$", ""))
+end
+
 --- Setup function for lazy.nvim / packer etc.
 function M.setup(opts)
 	M.config = vim.tbl_deep_extend("force", M.config, opts or {})

--- a/lua/telescope/_extensions/pterm.lua
+++ b/lua/telescope/_extensions/pterm.lua
@@ -6,7 +6,7 @@ local actions = require("telescope.actions")
 local action_state = require("telescope.actions.state")
 local previewers = require("telescope.previewers")
 
-local function trim_left_to_width(line, width)
+local function trim_right_to_width(line, width)
 	if width <= 0 then
 		return ""
 	end
@@ -14,25 +14,25 @@ local function trim_left_to_width(line, width)
 		return line
 	end
 
-	local prefix = "..."
-	if width <= #prefix then
-		return prefix:sub(1, width)
+	local suffix = "..."
+	if width <= #suffix then
+		return suffix:sub(1, width)
 	end
 
-	local target_width = width - #prefix
+	local target_width = width - #suffix
 	local low = 0
 	local high = vim.fn.strchars(line)
 	while low < high do
-		local mid = math.floor((low + high) / 2)
-		local tail = vim.fn.strcharpart(line, mid)
-		if vim.fn.strdisplaywidth(tail) > target_width then
-			low = mid + 1
+		local mid = math.ceil((low + high) / 2)
+		local head = vim.fn.strcharpart(line, 0, mid)
+		if vim.fn.strdisplaywidth(head) <= target_width then
+			low = mid
 		else
-			high = mid
+			high = mid - 1
 		end
 	end
 
-	return prefix .. vim.fn.strcharpart(line, low)
+	return vim.fn.strcharpart(line, 0, low) .. suffix
 end
 
 local function tail_preview_lines(text, width, height)
@@ -47,7 +47,7 @@ local function tail_preview_lines(text, width, height)
 	local first = math.max(1, #lines - height + 1)
 	local preview = {}
 	for i = first, #lines do
-		table.insert(preview, trim_left_to_width(lines[i], width))
+		table.insert(preview, trim_right_to_width(lines[i], width))
 	end
 	return preview
 end

--- a/lua/telescope/_extensions/pterm.lua
+++ b/lua/telescope/_extensions/pterm.lua
@@ -4,6 +4,87 @@ local finders = require("telescope.finders")
 local conf = require("telescope.config").values
 local actions = require("telescope.actions")
 local action_state = require("telescope.actions.state")
+local previewers = require("telescope.previewers")
+
+local function trim_left_to_width(line, width)
+	if width <= 0 then
+		return ""
+	end
+	if vim.fn.strdisplaywidth(line) <= width then
+		return line
+	end
+
+	local prefix = "..."
+	if width <= #prefix then
+		return prefix:sub(1, width)
+	end
+
+	local target_width = width - #prefix
+	local low = 0
+	local high = vim.fn.strchars(line)
+	while low < high do
+		local mid = math.floor((low + high) / 2)
+		local tail = vim.fn.strcharpart(line, mid)
+		if vim.fn.strdisplaywidth(tail) > target_width then
+			low = mid + 1
+		else
+			high = mid
+		end
+	end
+
+	return prefix .. vim.fn.strcharpart(line, low)
+end
+
+local function tail_preview_lines(text, width, height)
+	local lines = vim.split(text or "", "\n", { plain = true })
+	while #lines > 0 and lines[#lines] == "" do
+		table.remove(lines)
+	end
+	if #lines == 0 then
+		return { "(empty)" }
+	end
+
+	local first = math.max(1, #lines - height + 1)
+	local preview = {}
+	for i = first, #lines do
+		table.insert(preview, trim_left_to_width(lines[i], width))
+	end
+	return preview
+end
+
+local function make_previewer(pterm)
+	return previewers.new_buffer_previewer({
+		title = "pterm preview",
+		define_preview = function(self, entry, status)
+			status = status or {}
+			local session_name = entry and entry.value
+			if not session_name then
+				return
+			end
+
+			local width = 80
+			if status.preview_win and vim.api.nvim_win_is_valid(status.preview_win) then
+				width = vim.api.nvim_win_get_width(status.preview_win)
+			end
+			local height = 20
+			if status.preview_win and vim.api.nvim_win_is_valid(status.preview_win) then
+				height = vim.api.nvim_win_get_height(status.preview_win)
+			end
+
+			local text, err = pterm.snapshot_text(session_name)
+			local lines
+			if text then
+				lines = tail_preview_lines(text, width, height)
+			else
+				lines = { "Failed to load preview", vim.trim(tostring(err or "")) }
+			end
+
+			vim.api.nvim_set_option_value("modifiable", true, { buf = self.state.bufnr })
+			vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
+			vim.api.nvim_set_option_value("modifiable", false, { buf = self.state.bufnr })
+		end,
+	})
+end
 
 local function session_exists(pterm, session_name)
 	for _, name in ipairs(pterm.list()) do
@@ -35,6 +116,11 @@ local function sessions(opts)
 		})
 	end
 
+	local previewer = opts.previewer
+	if previewer == nil then
+		previewer = make_previewer(pterm)
+	end
+
 	pickers
 		.new(opts, {
 			prompt_title = "pterm sessions",
@@ -49,6 +135,7 @@ local function sessions(opts)
 				end,
 			}),
 			sorter = conf.generic_sorter(opts),
+			previewer = previewer,
 			attach_mappings = function(prompt_bufnr)
 				actions.select_default:replace(function()
 					actions.close(prompt_bufnr)

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -28,6 +28,9 @@ pub mod client {
 
     /// Request terminal redraw (no payload)
     pub const REDRAW: u8 = 0x04;
+
+    /// Request a plain-text snapshot of the visible terminal screen (no payload)
+    pub const SNAPSHOT_TEXT: u8 = 0x05;
 }
 
 /// Daemon → Client message types
@@ -43,6 +46,10 @@ pub mod server {
     /// Terminal state snapshot (sent on initial attach)
     /// Payload: escape sequences reproducing current terminal state
     pub const STATE_SYNC: u8 = 0x80;
+
+    /// Plain-text snapshot of the visible terminal screen
+    /// Payload: UTF-8 text rows separated by LF
+    pub const SNAPSHOT_TEXT: u8 = 0x81;
 }
 
 /// Encode a framed message into a Vec<u8>.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod session;
 use crate::paths::{find_sessions, session_dir, session_socket_path, socket_dir, SOCKET_FILENAME};
 use server::Server;
 use session::Session;
-use std::io;
+use std::io::{self, Read, Write};
 use std::os::unix::fs::FileTypeExt;
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -26,6 +26,8 @@ Usage:
   pterm list   [prefix]
   pterm kill   <session-name>
   pterm redraw <session-name>   # redraw terminal (resend snapshot)
+  pterm snapshot-text <session-name>
+               # print plain-text snapshot of current screen
   pterm socket <session-name>   # print socket path
 
 Session names may contain '/' for hierarchical sessions:
@@ -306,6 +308,74 @@ fn cmd_redraw(args: &[String]) -> io::Result<()> {
     Ok(())
 }
 
+fn read_single_response(
+    stream: &mut std::os::unix::net::UnixStream,
+    expected_msg_type: u8,
+    timeout: Duration,
+) -> io::Result<Vec<u8>> {
+    stream.set_read_timeout(Some(timeout))?;
+
+    let mut recv_buf = Vec::new();
+    let mut read_buf = vec![0u8; 65536];
+    loop {
+        match stream.read(&mut read_buf) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "daemon closed connection before sending response",
+                ));
+            }
+            Ok(n) => {
+                recv_buf.extend_from_slice(&read_buf[..n]);
+                for frame in pterm_proto::decode_frames(&mut recv_buf) {
+                    if frame.msg_type == expected_msg_type {
+                        return Ok(frame.payload);
+                    }
+                }
+            }
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+                ) =>
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "timed out waiting for daemon response",
+                ));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+fn cmd_snapshot_text(args: &[String]) -> io::Result<()> {
+    let name = args.first().map(|s| s.as_str()).unwrap_or_else(|| {
+        eprintln!("Error: session name required");
+        std::process::exit(1);
+    });
+
+    let sock = session_socket_path(name);
+    if !sock.exists() {
+        eprintln!("Error: session '{}' not found", name);
+        std::process::exit(1);
+    }
+
+    let mut stream = std::os::unix::net::UnixStream::connect(&sock)?;
+    let msg = pterm_proto::encode(pterm_proto::client::SNAPSHOT_TEXT, &[]);
+    stream.write_all(&msg)?;
+
+    let payload = read_single_response(
+        &mut stream,
+        pterm_proto::server::SNAPSHOT_TEXT,
+        Duration::from_secs(3),
+    )?;
+    let mut stdout = io::stdout().lock();
+    stdout.write_all(&payload)?;
+    stdout.write_all(b"\n")?;
+    Ok(())
+}
+
 fn cmd_socket(args: &[String]) -> io::Result<()> {
     let name = args.first().map(|s| s.as_str()).unwrap_or_else(|| {
         eprintln!("Error: session name required");
@@ -332,6 +402,7 @@ fn main() {
         "list" | "ls" => cmd_list(&args[2..]),
         "kill" => cmd_kill(&args[2..]),
         "redraw" => cmd_redraw(&args[2..]),
+        "snapshot-text" => cmd_snapshot_text(&args[2..]),
         "socket" => cmd_socket(&args[2..]),
         "-h" | "--help" | "help" => {
             print_usage();

--- a/src/server.rs
+++ b/src/server.rs
@@ -23,6 +23,8 @@ struct Client {
     large_send_buf_warned: bool,
     /// `true` until the initial snapshot has been sent.
     pending_snapshot: bool,
+    /// One-shot diagnostic clients should not receive normal terminal output.
+    diagnostic: bool,
 }
 
 pub struct Server {
@@ -192,6 +194,7 @@ impl Server {
                             send_buf: Vec::new(),
                             large_send_buf_warned: false,
                             pending_snapshot: true,
+                            diagnostic: false,
                         },
                     );
                 }
@@ -260,9 +263,18 @@ impl Server {
     }
 
     fn handle_pty_output(&mut self, buf: &mut [u8]) -> io::Result<()> {
-        // Drain all available PTY data (non-blocking) and flush immediately.
-        // No timer-based batching — the drain loop itself coalesces all bytes
-        // that are available at this instant.
+        self.drain_pty_output(buf)?;
+
+        if !self.pending_pty_output.is_empty() {
+            self.flush_pty_output();
+        }
+
+        Ok(())
+    }
+
+    fn drain_pty_output(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        // Drain all available PTY data (non-blocking). No timer-based batching
+        // -- the drain loop itself coalesces all bytes available right now.
         loop {
             match self.session.read_pty(buf) {
                 Ok(0) => break,
@@ -324,10 +336,6 @@ impl Server {
             }
         }
 
-        if !self.pending_pty_output.is_empty() {
-            self.flush_pty_output();
-        }
-
         Ok(())
     }
 
@@ -349,7 +357,13 @@ impl Server {
         let snapshot_ids: Vec<usize> = self
             .clients
             .iter()
-            .filter_map(|(&id, c)| if c.pending_snapshot { Some(id) } else { None })
+            .filter_map(|(&id, c)| {
+                if c.pending_snapshot && !c.diagnostic {
+                    Some(id)
+                } else {
+                    None
+                }
+            })
             .collect();
         for id in &snapshot_ids {
             log::info!("Client {} snapshot triggered by PTY output arrival", *id);
@@ -362,6 +376,9 @@ impl Server {
         let mut disconnected = Vec::new();
         let mut flush_ids = Vec::new();
         for (&id, client) in self.clients.iter_mut() {
+            if client.diagnostic {
+                continue;
+            }
             // Skip clients that just received a snapshot — they already have
             // the up-to-date screen state and must not get the raw bytes again.
             if snapshot_ids.contains(&id) {
@@ -523,6 +540,28 @@ impl Server {
                     redraw_data.extend_from_slice(&self.session.snapshot());
                     let msg = proto::encode(proto::server::STATE_SYNC, &redraw_data);
                     for (_, client) in self.clients.iter_mut() {
+                        client.send_buf.extend_from_slice(&msg);
+                    }
+                    flush_all = true;
+                }
+                proto::client::SNAPSHOT_TEXT => {
+                    log::info!("Snapshot text requested by client {}", client_id);
+                    if let Some(client) = self.clients.get_mut(&client_id) {
+                        client.diagnostic = true;
+                        client.pending_snapshot = false;
+                        client.send_buf.clear();
+                    }
+
+                    let mut pty_buf = vec![0u8; 65536];
+                    self.drain_pty_output(&mut pty_buf)?;
+                    if !self.pending_pty_output.is_empty() {
+                        self.flush_pty_output();
+                    }
+
+                    let payload = self.session.snapshot_text();
+                    let msg = proto::encode(proto::server::SNAPSHOT_TEXT, payload.as_bytes());
+                    if let Some(client) = self.clients.get_mut(&client_id) {
+                        client.send_buf.clear();
                         client.send_buf.extend_from_slice(&msg);
                     }
                     flush_all = true;

--- a/src/session.rs
+++ b/src/session.rs
@@ -384,6 +384,11 @@ fn build_snapshot(screen: &vt100::Screen, callbacks: &SessionCallbacks) -> Vec<u
     snapshot
 }
 
+fn build_snapshot_text(screen: &vt100::Screen) -> String {
+    let (_, cols) = screen.size();
+    screen.rows(0, cols).collect::<Vec<_>>().join("\n")
+}
+
 impl KittyKeyboardState {
     const MAX_STACK_DEPTH: usize = 64;
 
@@ -731,6 +736,11 @@ impl Session {
         build_snapshot(self.parser.screen(), self.parser.callbacks())
     }
 
+    /// Generate a plain-text snapshot of the visible terminal screen.
+    pub fn snapshot_text(&self) -> String {
+        build_snapshot_text(self.parser.screen())
+    }
+
     pub fn take_pending_da_queries(&mut self) -> (usize, usize) {
         self.parser.callbacks_mut().take_pending_da_queries()
     }
@@ -765,7 +775,10 @@ impl Session {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_snapshot, KittyKeyboardState, SessionCallbacks, TerminalOutputFilter};
+    use super::{
+        build_snapshot, build_snapshot_text, KittyKeyboardState, SessionCallbacks,
+        TerminalOutputFilter,
+    };
     use crate::constants::{DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS};
     use std::collections::VecDeque;
 
@@ -1305,5 +1318,13 @@ mod tests {
             has_esc_before,
             "state_formatted() sequences should appear before DECSCUSR in snapshot"
         );
+    }
+
+    #[test]
+    fn snapshot_text_rows_include_visible_screen_contents() {
+        let mut parser = vt100::Parser::new_with_callbacks(3, 8, 1000, SessionCallbacks::default());
+        parser.process(b"hello\r\nworld");
+
+        assert_eq!(build_snapshot_text(parser.screen()), "hello\nworld\n");
     }
 }


### PR DESCRIPTION
## Summary
- add a one-shot `snapshot-text` protocol/CLI command for visible terminal text
- expose `pterm.snapshot_text()` for Lua callers
- add a Telescope buffer previewer that shows the terminal tail trimmed to the preview window width

## Design notes
- preview requests are marked diagnostic so they do not receive normal terminal OUTPUT/STATE_SYNC frames
- the daemon drains pending PTY output before producing the text snapshot so the preview reflects the latest parser state
- preview rendering drops trailing blank terminal rows, takes the tail that fits the preview height, and left-trims long lines with `...`

## Tests
- cargo fmt --check
- cargo test
- cargo build
- stylua --check lua/pterm/init.lua lua/telescope/_extensions/pterm.lua
- luac -p lua/pterm/init.lua
- luac -p lua/telescope/_extensions/pterm.lua
- nvim --headless -u NONE -i NONE -c 'set rtp+=.' -c 'lua require("pterm")' -c 'qa'

Note: daemon-level manual verification could not be completed in the Codex exec environment because forked pterm daemons are not retained after `pterm new`, so the session socket disappears immediately.