### PR TITLE
Make Telescope preview snapshots async

### DIFF
--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -470,6 +470,54 @@ function M.snapshot_text(session_name)
 	return (output:gsub("\n$", ""))
 end
 
+--- Asynchronously return a plain-text snapshot of the visible terminal screen.
+function M.snapshot_text_async(session_name, callback)
+	if type(callback) ~= "function" then
+		error("callback required")
+	end
+
+	if not session_name or session_name == "" then
+		vim.schedule(function()
+			callback(nil, "Session name required")
+		end)
+		return nil
+	end
+
+	local ok, bin = pcall(find_binary)
+	if not ok then
+		vim.schedule(function()
+			callback(nil, bin)
+		end)
+		return nil
+	end
+
+	local system_ok, job = pcall(
+		vim.system,
+		{ bin, "snapshot-text", session_name },
+		{ text = true },
+		vim.schedule_wrap(function(result)
+			if result.code == 0 then
+				callback((result.stdout or ""):gsub("\n$", ""))
+				return
+			end
+
+			local err = result.stderr or result.stdout or ""
+			if err == "" then
+				err = "pterm snapshot-text exited with code " .. tostring(result.code)
+			end
+			callback(nil, err)
+		end)
+	)
+	if not system_ok then
+		vim.schedule(function()
+			callback(nil, job)
+		end)
+		return nil
+	end
+
+	return job
+end
+
 --- Return a diagnostic state dump as JSON.
 function M.dump(session_name)
 	if not session_name or session_name == "" then

--- a/lua/telescope/_extensions/pterm.lua
+++ b/lua/telescope/_extensions/pterm.lua
@@ -52,15 +52,41 @@ local function tail_preview_lines(text, width, height)
 	return preview
 end
 
+local function set_preview_lines(bufnr, lines)
+	if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
+		return
+	end
+
+	local ok = pcall(function()
+		vim.api.nvim_set_option_value("modifiable", true, { buf = bufnr })
+		vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+		vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
+	end)
+	if not ok and vim.api.nvim_buf_is_valid(bufnr) then
+		pcall(vim.api.nvim_set_option_value, "modifiable", false, { buf = bufnr })
+	end
+end
+
 local function make_previewer(pterm)
 	return previewers.new_buffer_previewer({
 		title = "pterm preview",
 		define_preview = function(self, entry, status)
 			status = status or {}
+			self.state = self.state or {}
+
 			local session_name = entry and entry.value
 			if not session_name then
 				return
 			end
+
+			local request_id = (self.state.pterm_preview_request_id or 0) + 1
+			self.state.pterm_preview_request_id = request_id
+
+			local previous_job = self.state.pterm_preview_job
+			if previous_job and previous_job.kill then
+				pcall(previous_job.kill, previous_job, 15)
+			end
+			self.state.pterm_preview_job = nil
 
 			local width = 80
 			if status.preview_win and vim.api.nvim_win_is_valid(status.preview_win) then
@@ -71,17 +97,24 @@ local function make_previewer(pterm)
 				height = vim.api.nvim_win_get_height(status.preview_win)
 			end
 
-			local text, err = pterm.snapshot_text(session_name)
-			local lines
-			if text then
-				lines = tail_preview_lines(text, width, height)
-			else
-				lines = { "Failed to load preview", vim.trim(tostring(err or "")) }
-			end
+			local bufnr = self.state.bufnr
+			set_preview_lines(bufnr, { "Loading preview..." })
 
-			vim.api.nvim_set_option_value("modifiable", true, { buf = self.state.bufnr })
-			vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
-			vim.api.nvim_set_option_value("modifiable", false, { buf = self.state.bufnr })
+			self.state.pterm_preview_job = pterm.snapshot_text_async(session_name, function(text, err)
+				if not self.state or self.state.pterm_preview_request_id ~= request_id then
+					return
+				end
+				self.state.pterm_preview_job = nil
+
+				local lines
+				if text then
+					lines = tail_preview_lines(text, width, height)
+				else
+					lines = { "Failed to load preview", vim.trim(tostring(err or "")) }
+				end
+
+				set_preview_lines(bufnr, lines)
+			end)
 		end,
 	})
 end


### PR DESCRIPTION
## Summary
- add async snapshot_text API using vim.system
- update Telescope previewer to render snapshots asynchronously
- cancel stale preview jobs and ignore out-of-date callbacks

## Verification
- nvim --headless require pterm
- Telescope extension load with stubs
- snapshot_text_async validation and missing-session callback checks
- git diff --check
- nix flake check