### PR TITLE
feat: show session directory basename in session lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ require("telescope").load_extension("pterm")
 ```
 
 Each session is shown as `<name> (<directory>)`, where the directory is the
-basename of the working directory the session was created from. Connected
+basename of the session shell's current working directory. The daemon tracks
+`cd` inside the session and refreshes it periodically. Connected
 sessions are marked with a `✔` prefix.
 The preview pane shows the tail of each session's current terminal screen,
 trimmed to the preview width.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ require("telescope").load_extension("pterm")
 :Telescope pterm sessions
 ```
 
-Connected sessions are shown with a `[connected]` prefix.
+Each session is shown as `<name> (<directory>)`, where the directory is the
+basename of the working directory the session was created from. Connected
+sessions are marked with a `✔` prefix.
 The preview pane shows the tail of each session's current terminal screen,
 trimmed to the preview width.
 If no existing session matches the current Telescope query, pressing `Enter`

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -114,6 +114,44 @@ function M.list()
 	return sessions
 end
 
+--- Return the working directory a session was created from, or nil if unknown.
+--- The daemon records this in `<socket_dir>/<name>/cwd` at creation time.
+function M.session_cwd(session_name)
+	if not session_name or session_name == "" then
+		return nil
+	end
+	local path = socket_dir() .. "/" .. session_name .. "/cwd"
+	local fd = io.open(path, "r")
+	if not fd then
+		return nil
+	end
+	local content = fd:read("*a")
+	fd:close()
+	if not content then
+		return nil
+	end
+	content = vim.trim(content)
+	if content == "" then
+		return nil
+	end
+	return content
+end
+
+--- Format a session name with its directory basename appended, e.g.
+--- "session_name (pterm)". Falls back to the bare name when the directory
+--- is unknown.
+function M.display_name(session_name)
+	local cwd = M.session_cwd(session_name)
+	if not cwd then
+		return session_name
+	end
+	local tail = vim.fn.fnamemodify(cwd, ":t")
+	if tail == "" then
+		return session_name
+	end
+	return session_name .. " (" .. tail .. ")"
+end
+
 function M.is_connected(session_name)
 	return connections[session_name] ~= nil
 end
@@ -581,7 +619,7 @@ function M.setup(opts)
 			vim.notify("No active pterm sessions", vim.log.levels.INFO)
 		else
 			for _, name in ipairs(sessions) do
-				vim.notify(name, vim.log.levels.INFO)
+				vim.notify(M.display_name(name), vim.log.levels.INFO)
 			end
 		end
 	end, { desc = "List active pterm sessions" })

--- a/lua/pterm/init.lua
+++ b/lua/pterm/init.lua
@@ -114,8 +114,9 @@ function M.list()
 	return sessions
 end
 
---- Return the working directory a session was created from, or nil if unknown.
---- The daemon records this in `<socket_dir>/<name>/cwd` at creation time.
+--- Return the session shell's current working directory, or nil if unknown.
+--- The daemon records this in `<socket_dir>/<name>/cwd` and refreshes it as the
+--- shell changes directory.
 function M.session_cwd(session_name)
 	if not session_name or session_name == "" then
 		return nil

--- a/lua/telescope/_extensions/pterm.lua
+++ b/lua/telescope/_extensions/pterm.lua
@@ -142,10 +142,11 @@ local function sessions(opts)
 	local entries = {}
 	for _, name in ipairs(session_names) do
 		local connected = pterm.is_connected(name)
+		local label = pterm.display_name(name)
 		table.insert(entries, {
 			value = name,
 			ordinal = name,
-			display = connected and ("[connected] " .. name) or name,
+			display = connected and ("✔ " .. label) or ("  " .. label),
 		})
 	end
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,8 +102,9 @@ fn cmd_new(args: &[String], quiet: bool) -> io::Result<()> {
     // Create session directory (including parent directories for hierarchical names)
     std::fs::create_dir_all(&sess_dir)?;
 
-    // Record the working directory so clients can show which directory a
-    // session belongs to (e.g. distinguishing git worktrees that share names).
+    // Record the initial working directory so clients can show which directory
+    // a session belongs to (e.g. distinguishing git worktrees that share names).
+    // The daemon refreshes this as the shell changes directory.
     if let Ok(cwd) = std::env::current_dir() {
         let _ = std::fs::write(
             sess_dir.join(CWD_FILENAME),

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@ mod pty;
 mod server;
 mod session;
 
-use crate::paths::{find_sessions, session_dir, session_socket_path, socket_dir, SOCKET_FILENAME};
+use crate::paths::{
+    find_sessions, session_dir, session_socket_path, socket_dir, CWD_FILENAME, SOCKET_FILENAME,
+};
 use server::Server;
 use session::Session;
 use std::io::{self, Read, Write};
@@ -99,6 +101,15 @@ fn cmd_new(args: &[String], quiet: bool) -> io::Result<()> {
 
     // Create session directory (including parent directories for hierarchical names)
     std::fs::create_dir_all(&sess_dir)?;
+
+    // Record the working directory so clients can show which directory a
+    // session belongs to (e.g. distinguishing git worktrees that share names).
+    if let Ok(cwd) = std::env::current_dir() {
+        let _ = std::fs::write(
+            sess_dir.join(CWD_FILENAME),
+            cwd.to_string_lossy().as_bytes(),
+        );
+    }
 
     // Daemonize: fork into background
     match unsafe { nix::unistd::fork() } {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -5,6 +5,10 @@ use std::path::{Path, PathBuf};
 /// Socket file name within a session directory.
 pub const SOCKET_FILENAME: &str = "socket";
 
+/// File name within a session directory recording the working directory the
+/// session was created from.
+pub const CWD_FILENAME: &str = "cwd";
+
 pub fn socket_dir() -> PathBuf {
     if let Ok(dir) = std::env::var("PTERM_SOCKET_DIR") {
         return PathBuf::from(dir);

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -5,9 +5,54 @@ use std::path::{Path, PathBuf};
 /// Socket file name within a session directory.
 pub const SOCKET_FILENAME: &str = "socket";
 
-/// File name within a session directory recording the working directory the
-/// session was created from.
+/// File name within a session directory recording the session shell's current
+/// working directory. Written at creation and refreshed by the daemon.
 pub const CWD_FILENAME: &str = "cwd";
+
+/// Look up the current working directory of a running process by pid.
+/// Returns `None` if the process is gone or the lookup is unsupported.
+#[cfg(target_os = "linux")]
+pub fn process_cwd(pid: i32) -> Option<PathBuf> {
+    std::fs::read_link(format!("/proc/{pid}/cwd")).ok()
+}
+
+#[cfg(target_os = "macos")]
+pub fn process_cwd(pid: i32) -> Option<PathBuf> {
+    use nix::libc;
+    use std::ffi::{CStr, OsStr};
+    use std::os::unix::ffi::OsStrExt;
+
+    let mut info: libc::proc_vnodepathinfo = unsafe { std::mem::zeroed() };
+    let size = std::mem::size_of::<libc::proc_vnodepathinfo>() as libc::c_int;
+    // SAFETY: `info` is a zeroed, correctly-sized buffer for PROC_PIDVNODEPATHINFO.
+    // proc_pidinfo writes at most `size` bytes and returns the number written.
+    let n = unsafe {
+        libc::proc_pidinfo(
+            pid,
+            libc::PROC_PIDVNODEPATHINFO,
+            0,
+            &mut info as *mut _ as *mut libc::c_void,
+            size,
+        )
+    };
+    if n < size {
+        return None;
+    }
+    // vip_path is a fixed-size, NUL-terminated C string buffer. Its element type
+    // varies across libc versions, so read it through a byte pointer.
+    let ptr = (&info.pvi_cdir.vip_path) as *const _ as *const libc::c_char;
+    // SAFETY: vip_path is NUL-terminated within the fixed-size buffer above.
+    let bytes = unsafe { CStr::from_ptr(ptr) }.to_bytes();
+    if bytes.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(OsStr::from_bytes(bytes)))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn process_cwd(_pid: i32) -> Option<PathBuf> {
+    None
+}
 
 pub fn socket_dir() -> PathBuf {
     if let Ok(dir) = std::env::var("PTERM_SOCKET_DIR") {

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::io::{self, Read, Write};
 use std::os::unix::fs::FileTypeExt;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const LISTENER: Token = Token(0);
 const PTY_BASE: Token = Token(0x1000_0000);
@@ -15,6 +15,9 @@ const DA1_RESPONSE: &[u8] = b"\x1b[?62;22c"; // Primary Device Attributes (DA1)
 const DA2_RESPONSE: &[u8] = b"\x1b[>1;10;0c"; // Secondary Device Attributes (DA2)
 const DA_QUERY_WARN_THRESHOLD: usize = 2;
 const LARGE_SEND_BUF_WARN_BYTES: usize = 64 * 1024;
+/// How often the daemon re-reads the child shell's working directory and
+/// refreshes the `cwd` file so session lists can follow `cd`.
+const CWD_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 
 struct Client {
     stream: UnixStream,
@@ -38,6 +41,12 @@ pub struct Server {
     pending_pty_output: Vec<u8>,
     /// `true` after the EXIT message has been broadcast to clients.
     exit_sent: bool,
+    /// Path of the `cwd` file recording the session's working directory.
+    cwd_path: PathBuf,
+    /// Last cwd written to `cwd_path`, to skip redundant writes.
+    last_cwd: Option<String>,
+    /// When the cwd was last refreshed from the child process.
+    last_cwd_refresh: Instant,
 }
 
 impl Server {
@@ -48,6 +57,11 @@ impl Server {
         std::fs::create_dir_all(session_dir)?;
 
         let socket_path = session_dir.join("socket");
+        let cwd_path = session_dir.join(crate::paths::CWD_FILENAME);
+        let last_cwd = std::fs::read_to_string(&cwd_path)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
 
         if socket_path.exists() {
             std::fs::remove_file(&socket_path)?;
@@ -79,6 +93,9 @@ impl Server {
             next_client_id: 0,
             pending_pty_output: Vec::new(),
             exit_sent: false,
+            cwd_path,
+            last_cwd,
+            last_cwd_refresh: Instant::now(),
         })
     }
 
@@ -110,6 +127,8 @@ impl Server {
 
             self.poll
                 .poll(&mut events, Some(Duration::from_millis(100)))?;
+
+            self.refresh_cwd();
 
             for event in events.iter() {
                 match event.token() {
@@ -170,6 +189,28 @@ impl Server {
         let _ = std::fs::remove_file(&self.socket_path);
         log::info!("Server shut down for session '{}'", self.session.name);
         Ok(())
+    }
+
+    /// Re-read the child shell's working directory and update the `cwd` file
+    /// when it changes, so session lists reflect `cd` inside the session.
+    /// Throttled to `CWD_REFRESH_INTERVAL`.
+    fn refresh_cwd(&mut self) {
+        if self.last_cwd_refresh.elapsed() < CWD_REFRESH_INTERVAL {
+            return;
+        }
+        self.last_cwd_refresh = Instant::now();
+
+        let pid = self.session.pty.child_pid.as_raw();
+        let cwd = match crate::paths::process_cwd(pid) {
+            Some(p) => p.to_string_lossy().into_owned(),
+            None => return,
+        };
+        if self.last_cwd.as_deref() == Some(cwd.as_str()) {
+            return;
+        }
+        if std::fs::write(&self.cwd_path, cwd.as_bytes()).is_ok() {
+            self.last_cwd = Some(cwd);
+        }
     }
 
     fn accept_client(&mut self) -> io::Result<()> {


### PR DESCRIPTION
## Summary
- セッションの作業ディレクトリを `<socket_dir>/<name>/cwd` に記録し、Telescope ピッカーと `:PtermList` でセッション名にディレクトリのベース名を添えて表示（例: `session_name (pterm)`）。git worktree などディレクトリと対応しない命名でも識別しやすくなる
- **daemon がセッション内の `cd` を追従**: 2 秒間隔で子シェルの現在ディレクトリを再取得し、変化時に `cwd` ファイルを更新する。作成時のディレクトリ固定ではなく現在地を反映
- 幅を取る `[connected]` マーカーをコンパクトなチェックマーク `✔` に変更

## 実装メモ
- 初期 CWD は `cmd_new` でセッションディレクトリ作成直後に `std::env::current_dir()` を書き込む（`pterm new` / `open` 両経路）
- daemon は poll ループ内で `paths::process_cwd(pid)` を 2 秒ごとに呼び、`<socket_dir>/<name>/cwd` を変化時のみ更新（`Server::refresh_cwd`）
- `process_cwd` は依存追加なしの自前実装: Linux は `/proc/<pid>/cwd` の readlink、macOS は libc の `proc_pidinfo(PROC_PIDVNODEPATHINFO)`
  - 検討した `libproc` は macOS で `pidcwd` 未実装、`darwin-libproc` は `memchr = "~2.3"` 制約で env_logger 経由の regex を大幅ダウングレードさせるため不採用
- `find_sessions` はディレクトリのみを辿るため `cwd` ファイルはセッションと誤認されない
- ディレクトリ不明時は従来通り名前のみ表示にフォールバック

## Test plan
- [x] `cargo build` / `cargo clippy` / `cargo test`（30件パス）
- [x] macOS で end-to-end 確認: セッション内 `cd /tmp` 後、約 2 秒で `cwd` ファイルが `/private/tmp` に更新されることを確認
- [x] `pterm list` が `cwd` ファイルの影響を受けないことを確認
- [ ] Neovim 上で Telescope ピッカー / `:PtermList` の表示を確認
- [ ] Linux 環境での動作確認（`process_cwd` の `/proc` 経路は cfg ゲートのため macOS では未コンパイル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)